### PR TITLE
agent_comm and env_comm are intracomm, so does not need different names

### DIFF
--- a/exarl/learner_base.py
+++ b/exarl/learner_base.py
@@ -229,13 +229,13 @@ class ExaLearner():
             current_state = self.env.reset()
             total_reward=0
             done = True # for leaders
-            if self.leader is False:
+            if is_leader is False:
                 done = False
             all_done = False
             root = 0
             if rank == 0:
                 root = MPI.ROOT # remote leader
-            if rank != 0 and self.leader == True:
+            if rank != 0 and is_leader == True:
                 root = MPI.PROC_NULL
             
             while all_done!=True:
@@ -302,7 +302,7 @@ class ExaLearner():
 
                 ## Exit criteria
                 all_done = comm.allreduce(done, op=MPI.LAND)
-           
+          
             end_time_episode = time.time()
             mtim = end_time_episode - start_time_episode 
             ptim = comm.reduce(mtim, op=MPI.SUM, root=0)


### PR DESCRIPTION
I think I understand why we would want to selectively initiate an `agent` object, but it seems the way it was set up for `run_exarl` led to the error Brian F. is facing, and I was also facing exactly the same error on OLCF Summit, which was causing `run_exarl` to hang. 
```
  File "driver/driver_example.py", line 15, in <module>
    exa_learner = erl.ExaLearner(run_params)
  File "/gpfs/alpine/ast153/scratch/saghosh/codes/exarl-devel-latest/ExaRL/exarl/learner_base.py", line 54, in __init__
    self.set_config(run_params)
  File "/gpfs/alpine/ast153/scratch/saghosh/codes/exarl-devel-latest/ExaRL/exarl/learner_base.py", line 133, in set_config
    self.agent.set_config(params)
AttributeError: 'NoneType' object has no attribute 'set_config'
Traceback (most recent call last):
  File "driver/driver_example.py", line 15, in <module>
    exa_learner = erl.ExaLearner(run_params)
  File "/gpfs/alpine/ast153/scratch/saghosh/codes/exarl-devel-latest/ExaRL/exarl/learner_base.py", line 54, in __init__
    self.set_config(run_params)
  File "/gpfs/alpine/ast153/scratch/saghosh/codes/exarl-devel-latest/ExaRL/exarl/learner_base.py", line 133, in set_config
    self.agent.set_config(params)
AttributeError: 'NoneType' object has no attribute 'set_config'
```
So this pull request contains the modification to resolve the hanging issue of `run_exarl` by doing two things:
1. Agent initialization outside if-loop.
2. Treating agent/env intracomms as same, so only a single comm-split is needed.
Apart from this, it also contains some minor fixes to the two functions I had added `run_exarl_two_groups` and `run_exarl_multi_groups`. However, they are still hanging for me on Summit. I am working on resolving the issue.
