### PR TITLE
Convergence cutoff, hyper-parameter tuning, and more...

### DIFF
--- a/bsuite/SingleRun.pm
+++ b/bsuite/SingleRun.pm
@@ -6,8 +6,8 @@ use Time::HiRes qw(usleep);
 my $user = "userName";
 my $partition = "partitionName";
 my $overSubFactor = 2;
-my $defaultThreashold = 1;
-my $threashold = $defaultThreashold;
+my $defaultThreshold = 1;
+my $threshold = $defaultThreshold;
 
 sub setPartition
 {
@@ -62,20 +62,20 @@ sub throttleCommand
     my $total = getCurrentTotalNodes();
     my $avail = getCurrentAvailableNodes();
     my $load = getCurrentLoad();
-    if($threashold < $avail)
+    if($threshold < $avail)
     {
-        $threashold = int($avail*$overSubFactor);
+        $threshold = int($avail*$overSubFactor);
     }
     else
     {
         my $max = $total * $overSubFactor;
-        if($max < $threashold)
+        if($max < $threshold)
         {
-            $threashold = $max;
+            $threshold = $max;
         }
     }
     my $secs = 100;
-    while($load >= $threashold)
+    while($load >= $threshold)
     {
         usleep($secs);
         if($secs < 1000000)
@@ -91,7 +91,36 @@ sub throttleCommand
     $load = getCurrentLoad();
     my $running = getCurrentRunning();
     my $percentage = 100 * $running / $total;
-    print("Nodes: $total Avail: $avail Load: $load Percent: $percentage\n");
+    print("Nodes: $total Avail: $avail Load: $load Percent: $percentage Threshold: $threshold\n");
+}
+
+sub greedyThrottleCommand
+{   
+    $threshold = shift(@_);
+    my $command = shift(@_);
+    my $total = getCurrentTotalNodes();
+    my $avail = getCurrentAvailableNodes();
+    my $load = getCurrentLoad();
+     
+    
+    my $secs = 100;
+    while($load >= $threshold)
+    {
+        usleep($secs);
+        if($secs < 1000000)
+        {
+            $secs+=100;
+        }
+        $load = getCurrentLoad();
+    }
+    my $load = getCurrentLoad();
+    runCommand($command);
+    $total = getCurrentTotalNodes();
+    $avail = getCurrentAvailableNodes();
+    $load = getCurrentLoad();
+    my $running = getCurrentRunning();
+    my $percentage = 100 * $running / $total;
+    print("Nodes: $total Avail: $avail Load: $load Percent: $percentage Threshold: $threshold\n");
 }
 
 sub waitUntilFileExists

--- a/bsuite/bsuite_batch.pl
+++ b/bsuite/bsuite_batch.pl
@@ -41,7 +41,7 @@ sub usage() {
     print "    -h: Print this message\n\n";
     print "Example usage:\n";
     print "  ./bsuite/bsuite_batch.pl -N 2 -n 2 -a \"-x node15,node28,node22,node42,node33\" -b developer -o out -s 2 -e 100 -p 100 slurm\n";
-    print "  ./bsuite/bsuite_batch.pl -N 2 -n 2 -a \"-A --agent async\" -o out slurm\n";
+    print "  ./bsuite/bsuite_batch.pl -N 2 -n 2 -A \"--agent async\" -o out slurm\n";
     print "  ./bsuite/bsuite_batch.pl -N 1 -n 1 -S ./script/cori_V100_gpu.sh -b memory -s 1 -o out slurm\n";
     print "  ./bsuite/bsuite_batch.pl -D slurm\n";
     print "  ./bsuite/bsuite_batch.pl -B all slurm\n";

--- a/bsuite/bsuite_batch.pl
+++ b/bsuite/bsuite_batch.pl
@@ -173,7 +173,7 @@ sub getSbatchCommand {
         # Set the srun command in script
         for(my $i=0; $i<=$#template; $i++) {
             if($template[$i] =~ /srun/) {
-                $template[$i] = "srun python $driver_path --env Bsuite-v0 --bsuite_id $bench --seed_number $seed --n_episodes $episode $steps $output&> $outfile";
+                $template[$i] = "srun python $driver_path --env Bsuite-v0 --bsuite_id $bench --seed_number $seed --n_episodes $episode $steps $A $output&> $outfile";
             }
         }
 
@@ -212,7 +212,7 @@ sub getSlurmCommand {
         makeDir($exp_dir);
         my $output = "--output_dir $bench_dir_name";
 
-        return "srun -p $partition -N $N -n $n $a python $driver_path --env Bsuite-v0 --bsuite_id $bench --seed_number $seed --n_episodes $episode $steps $output&> $outfile &";
+        return "srun -p $partition -N $N -n $n $a python $driver_path --env Bsuite-v0 --bsuite_id $bench --seed_number $seed --n_episodes $episode $steps $A $output&> $outfile &";
     }
     return 0;
 }

--- a/exarl/__init__.py
+++ b/exarl/__init__.py
@@ -12,3 +12,21 @@ from exarl.base import ExaEnv
 from exarl.base import ExaWorkflow
 from exarl.base import ExaLearner
 from exarl.base import ExaData
+
+from exarl.utils.globals import ExaGlobals
+import importlib
+import sys
+try:
+    load_agent_module = ExaGlobals.lookup_params('load_agent_module')
+    print(sys.path)
+    importlib.import_module(load_agent_module)
+    print("Loaded:", load_agent_module)
+except ExaGlobals.GlobalDoesNotExist:
+    pass
+
+try:
+    load_env_module = ExaGlobals.lookup_params('load_env_module')
+    importlib.import_module(load_env_module)
+    print("Loaded:", load_env_module)
+except ExaGlobals.GlobalDoesNotExist:
+    pass

--- a/exarl/base/learner_base.py
+++ b/exarl/base/learner_base.py
@@ -111,3 +111,12 @@ class ExaLearner:
 
     def run(self):
         self.workflow.run(self)
+
+    def final_number_of_episodes(self):
+        return self.workflow.get_total_episodes_run()
+
+    def final_total_reward(self):
+        return self.workflow.get_total_reward()
+
+    def final_rolling_reward(self):
+        return self.workflow.get_rolling_reward()

--- a/exarl/candlelib/candle/__init__.py
+++ b/exarl/candlelib/candle/__init__.py
@@ -60,7 +60,7 @@ from exarl.candlelib.helper_utils import search
 # import benchmark-dependent utils
 import sys
 
-if search(sys.modules, 'keras'):
+if search(sys.modules, 'keras') or search(sys.modules, 'tensorflow'):
     print('Importing candle utils for keras')
 
     # import from keras_utils

--- a/exarl/candlelib/default_utils.py
+++ b/exarl/candlelib/default_utils.py
@@ -645,19 +645,57 @@ def get_choice(name):
 
     return mapped
 
-def get_next_run(output_dir):
-    num = 0
-    next_run = "RUN000" 
-    files = list(os.listdir(output_dir))
-    while next_run in files:
-        next_run = "RUN"+"{0:03d}".format(num)
-        num+=1
-    return next_run
+def get_files(dir, filter=None, singleLevel=False):
+    """
+    This grabs all the files in a directory.  The filter is used
+    to select files that match a sub-string.  If no filters is
+    supplied, all files in the directory will be return.
 
-def reset_dir(directory):
-    for f in os.listdir(directory):
-        os.remove("{}/{}".format(directory, f))
-    os.removedirs(directory)
+    Parameters
+    ----------
+    dir : str
+        Directory to get files from
+    filter : str, optional
+        Sub-strings to look for in filename
+
+    Returns
+    -------
+    list
+        list of filenames
+    """
+    ret = []
+    for root, dirs, files in os.walk(dir):
+        for f in files:
+            if filter is None or filter in f:
+                file = os.path.join(root, f)
+                ret.append(file)
+        if singleLevel:
+            break
+    return ret
+
+def get_next_run(output_dir):
+    """
+    This will look for the next available RUN directory without any logs.
+    There is a race condition if the exp is started but no logs are written.
+    The purpose of this function is to overwrite logs leading to
+    incorrect plotting of results.
+
+    Parameters
+    ----------
+    output_dir : string
+        The dir to run the lowest level exp in.
+    """
+    num = 0
+    next_run = "RUN000"
+    dirs = list(os.listdir(output_dir))
+    while next_run in dirs:
+        files = get_files(os.path.join(output_dir, next_run), filter=".log", singleLevel=True)
+        if len(files):
+            next_run = "RUN" + "{0:03d}".format(num)
+            num += 1
+        else:
+            break
+    return next_run
 
 def directory_from_parameters(params, commonroot='Output'):
     """ Construct output directory path with unique IDs from parameters
@@ -670,7 +708,6 @@ def directory_from_parameters(params, commonroot='Output'):
             String to specify the common folder to store results.
 
     """
-
     if commonroot in set(['.', './']):  # Same directory --> convert to absolute path
         outdir = os.path.abspath('.')
     else:  # Create path specified
@@ -682,9 +719,10 @@ def directory_from_parameters(params, commonroot='Output'):
         if not os.path.exists(outdir):
             os.makedirs(outdir, exist_ok=True)
 
-        #Save to the next available run
+        # Save to the next available run
         if 'run_id' not in params:
             params['run_id'] = get_next_run(outdir)
+
         outdir = os.path.abspath(os.path.join(outdir, params['run_id']))
         if not os.path.exists(outdir):
             os.makedirs(outdir, exist_ok=True)

--- a/exarl/config/hyper_params.json
+++ b/exarl/config/hyper_params.json
@@ -1,0 +1,11 @@
+{
+"parameters": {
+    "learning_rate": [0.001, 0.1],
+    "learning_iterations_per_round" : [1, 8],
+    "discount_rate": [0.9, 0.99],
+    "clip_epsilon": [0.0, 0.5],
+    "epsilon_decay_rate_denominator": [1, 500]
+},
+"objective": "last_rolling_reward",
+"sampler": "tpe"
+}

--- a/exarl/config/hyper_params.json
+++ b/exarl/config/hyper_params.json
@@ -1,11 +1,14 @@
 {
+"agent": "DQN-v0",
 "parameters": {
-    "learning_rate": [0.001, 0.1],
-    "learning_iterations_per_round" : [1, 8],
-    "discount_rate": [0.9, 0.99],
-    "clip_epsilon": [0.0, 0.5],
-    "epsilon_decay_rate_denominator": [1, 500]
+    "gamma": [0.001, 0.1],
+    "batch_size": [5, 128],
+    "epsilon" : [0.01, 1.0],
+    "epsilon_decay" : [0.1, 1.0],
+    "learning_rate" : [0.001, 1.0],
+    "tau" : [0.01, 1.0]
 },
-"objective": "last_rolling_reward",
-"sampler": "tpe"
+"objective": "all",
+"sampler": "tpe",
+"trials": 1
 }

--- a/exarl/config/learner_cfg.json
+++ b/exarl/config/learner_cfg.json
@@ -12,5 +12,7 @@
     ],
     "log_frequency": 1,
     "profile": "None",
-    "model_type": "MLP"
+    "model_type": "MLP",
+    "clip_rewards":"False",
+    "plot_rolling_range": 25
 }

--- a/exarl/config/learner_cfg.json
+++ b/exarl/config/learner_cfg.json
@@ -1,18 +1,19 @@
 {
     "agent": "DQN-v0",
-    "env": "ExaCartPoleStatic-v0",
+    "env": "CartPole-v0",
     "workflow": "sync",
     "n_episodes": 10,
     "n_steps": 10,
-    "output_dir": "./results_dir/",
+    "output_dir": "./results/",
     "process_per_env": 1,
     "log_level": [
         3,
         3
     ],
-    "log_frequency": 1,
-    "profile": "None",
     "model_type": "MLP",
     "clip_rewards":"False",
-    "plot_rolling_range": 25
+    "rolling_reward_length": 4,
+    "cutoff" : 0.00000,
+    "log_frequency": 1,
+    "profile": "None"
 }

--- a/exarl/config/workflow_cfg/async.json
+++ b/exarl/config/workflow_cfg/async.json
@@ -5,7 +5,5 @@
     "batch_step_frequency": 1,
     "save_weights_per_episode": "false",
     "action_type": "variable",
-    "cutoff" : 0.00001,
-    "rolling_reward_length" : -1,
     "mpi4py_rc": "false"
 }

--- a/exarl/config/workflow_cfg/async.json
+++ b/exarl/config/workflow_cfg/async.json
@@ -1,8 +1,11 @@
 {
     "learner_procs": 1,
-    "episode_block": "false",
-    "batch_frequency": 1,
+    "episode_block": "False",
+    "batch_episode_frequency": 1,
+    "batch_step_frequency": 1,
     "save_weights_per_episode": "false",
     "action_type": "variable",
+    "cutoff" : 0.00001,
+    "rolling_reward_length" : -1,
     "mpi4py_rc": "false"
 }

--- a/exarl/config/workflow_cfg/sync.json
+++ b/exarl/config/workflow_cfg/sync.json
@@ -5,7 +5,5 @@
     "batch_step_frequency": 1,
     "save_weights_per_episode": "false",
     "action_type": "variable",
-    "mpi4py_rc": "true",
-    "cutoff" : 0.00001,
-    "rolling_reward_length" : -1
+    "mpi4py_rc": "true"
 }

--- a/exarl/config/workflow_cfg/sync.json
+++ b/exarl/config/workflow_cfg/sync.json
@@ -1,8 +1,11 @@
 {
     "learner_procs": 1,
-    "episode_block": "false",
-    "batch_frequency": 1,
+    "episode_block": "False",
+    "batch_episode_frequency": 1,
+    "batch_step_frequency": 1,
     "save_weights_per_episode": "false",
     "action_type": "variable",
-    "mpi4py_rc": "true"
+    "mpi4py_rc": "true",
+    "cutoff" : 0.00001,
+    "rolling_reward_length" : -1
 }

--- a/exarl/driver/__main__.py
+++ b/exarl/driver/__main__.py
@@ -24,9 +24,10 @@ import tensorflow
 # import torch
 import exarl
 from exarl.utils.profile import ProfileConstants
+import os
 import exarl.utils.analyze_reward as ar
+from exarl.utils.renderDMC import render_tmp
 
-# Create learner object and run
 exa_learner = exarl.ExaLearner()
 
 # MPI communicator
@@ -48,6 +49,10 @@ else:
     if rank == 0:
         print("Average elapsed time = ", elapse / size)
         print("Maximum elapsed time = ", max_elapse)
+
+print("Final number of episodes =", exa_learner.final_number_of_episodes())
+print("Total reward =", exa_learner.final_total_reward())
+print("Final rolling reward =", exa_learner.final_rolling_reward()[0])
 
 # Save rewards vs. episodes plot
 if rank == 0:

--- a/exarl/driver/__main__.py
+++ b/exarl/driver/__main__.py
@@ -20,7 +20,8 @@
 #                    under Contract DE-AC05-76RL01830
 import time
 import numpy as np
-
+import tensorflow
+# import torch
 import exarl
 from exarl.utils.profile import ProfileConstants
 import exarl.utils.analyze_reward as ar

--- a/exarl/driver/__main__.py
+++ b/exarl/driver/__main__.py
@@ -50,10 +50,9 @@ else:
         print("Average elapsed time = ", elapse / size)
         print("Maximum elapsed time = ", max_elapse)
 
-print("Final number of episodes =", exa_learner.final_number_of_episodes())
-print("Total reward =", exa_learner.final_total_reward())
-print("Final rolling reward =", exa_learner.final_rolling_reward()[0])
-
 # Save rewards vs. episodes plot
 if rank == 0:
+    print("Final number of episodes =", exa_learner.final_number_of_episodes())
+    print("Total reward =", exa_learner.final_total_reward())
+    print("Final rolling reward =", exa_learner.final_rolling_reward()[0])
     ar.save_reward_plot()

--- a/exarl/driver/hyper-tune.py
+++ b/exarl/driver/hyper-tune.py
@@ -1,20 +1,64 @@
 #!/usr/bin/env python
-#SBATCH --time=48:00:00
-#SBATCH --exclusive
 
-import sys
+from collections import deque
+import multiprocessing
 import subprocess
 import optuna
 import json
-import numpy as np
-import matplotlib.pyplot as plt
 
+"""
+To use:
+    sbatch -N [number of nodes] ./exarl/driver/hyper-tune.py
+
+Make sure the configuration files have the correct number of steps/episodes, workflow, agent, and environment
+set correctly.  The hyper_params.json file will contain the parameters to explore.  Each parameter should
+have the mins and max ranges set.  The following is the format:
+
+    {
+        "parameters": {
+            "param1": [0.001, 0.1],
+            "param2": [5, 128]
+        },
+        "objective": "all",
+        "sampler": "tpe",
+        "trials": 1
+    }
+
+The objective and sampler fields configure which objective function to maximize and which optuna function to
+use respectively.  Passing all for either will cycle through all objective/sampler.  This file should be
+launched from the directory just before exarl.  Also we try to reserve a single node for optuna so if you want
+to launch 10 trials in parallel, sbatch -N 11.
+
+The results dir set in the learner_cfg will contain ALL the results for each trial marked by optimizer
+and trial number.
+"""
+
+"""
+This is the path to the hyper parameters to optimize!
+"""
+path_to_json = "./exarl/config/hyper_params.json"
+
+"""
+These are the objective functions we will be optimizing:
+    Last Rolling Reward: This is the rolling reward on exit
+    Rolling Reward per Time: This is the rolling reward normalized to the total runtime
+    Rolling Reward per Episode: This is the rolling reward normalized to the total number of episodes
+    Total Reward per Time: This is the total reward normalized to the total runtime
+    Total Reward per Episode: This is the total reward normalized to the total number of episodes
+"""
 objectives = {
-    "last_rolling_reward": lambda x: x[0],
-    "reward_per_time": lambda x: x[0]/x[1],
-    "reward_per_episode": lambda x: x[0]/x[2]
+    "rolling_reward": lambda x: x[0],
+    "total_reward": lambda x: x[1],
+    "rolling_reward_per_time": lambda x: x[0] / x[1],
+    "rolling_reward_per_episode": lambda x: x[0] / x[2],
+    "total_reward_per_time": lambda x: x[0] / x[1],
+    "total_reward_per_episode": lambda x: x[0] / x[2]
 }
 
+"""
+These are the samples that are readily available from optuna:
+    https://optuna.readthedocs.io/en/stable/reference/samplers/index.html
+"""
 samplers = {
     "tpe": optuna.samplers.TPESampler,
     "random": optuna.samplers.RandomSampler,
@@ -23,58 +67,171 @@ samplers = {
 }
 
 class Optimizer:
-    def __init__(self, params, objective_func, sampler, n_trials=100, eps=30):
+    """
+    This class is a utility built around optuna's study to support parallel study execution using Slurm.
+    Optuna parallelizes the study using built in python threading.  We leaverage this "threading" by
+    launching a srun command per thread.  These commands are then run in parallel on seperate nodes.
+    The results of the commands are captured and parsed and then passed into the study.
+
+    See the following for information on parallelizing the study:
+    https://optuna.readthedocs.io/en/stable/reference/generated/optuna.study.Study.html#optuna.study.Study.optimize
+    Notice this is how they expect to parallize the study...
+    https://optuna.readthedocs.io/en/stable/tutorial/10_key_features/004_distributed.html#distributed
+
+    Attributes
+    ----------
+    params : dictionary
+        The parameters with their upper and lower bounds to explore
+    objective_func : function
+        This is the function that parses the returned values of a trial giving a score
+    sampler : optuna.sampler
+        The type of sampler to use in the study
+    n_trials : int
+        How many trials to run
+    exp : string
+        The name of the experiment folder
+    all_nodes : list
+        List of node names to send srun commands to.
+    """
+    def __init__(self, params, objective_func, sampler, n_trials=100, exp="EXP000"):
         self.params = params
         self.objective_func = objective_func
         self.sampler = sampler
         self.n_trials = n_trials
-        self.n_episodes = eps
+        self.exp = exp
+        self.manager = multiprocessing.Manager()
+        self.lock = self.manager.Lock()
         self.all_nodes = self.get_nodes()
-        self.log = [[0, 0]] 
+        # JS: Leave the first node for optuna
+        if len(self.all_nodes) > 1:
+            self.all_nodes = self.all_nodes[1:]
 
     def optimize(self):
-        #print("Python", sys.version, "All Nodes", all_nodes, flush=True)
-        print("STUDY: ", self.sampler, self.n_trials)
+        """
+        This function performs the study.
+
+        Returns
+        -------
+        dictionary
+            This is the list of params and the best achieved value
+        """
+        print("Study: ", self.sampler, self.n_trials)
+        # JS: Notice we are maximizing!
         study = optuna.create_study(direction="maximize", sampler=self.sampler())
         study.optimize(self.objective, n_trials=self.n_trials, n_jobs=len(self.all_nodes))
-
-        best_params = study.best_params
-        return [(p, best_params[p]) for p in best_params], self.log
+        return study.best_params
 
     def get_nodes(self):
+        """
+        This function uses scontrol to get a list of the nodes in sbatch job.
+        They are then return as a list.
+
+        Returns
+        -------
+        list
+            Names of all nodes in job
+        """
         cmd = command("scontrol show hostnames", wait=True)
         return [x for x in cmd.out.split('\n') if len(x) > 0]
 
-    def srun_prefix(self, cmd, nodeId=None, nodes=1, procs=1):
-        if nodeId:
-            return " ".join(["srun -N", str(nodes), "-n", str(procs), "-w", nodeId, cmd])
-        else:
-            return " ".join(["srun -N", str(nodes), "-n", str(procs), cmd])
+    def srun_prefix(self, cmd, nodeId, nodes=1, procs=1):
+        """
+        Adds srun and srun options to the command to run.
 
-    def run_cmd(self, params, node_id=None):
-        text = "python exarl/driver --n_episodes {}".format(self.n_episodes)
+        TODO: Propagate nodes > 1 and procs > 1 option through the rest
+        of the script.  Maybe add to the hyperparameter json options.
+
+        Returns
+        -------
+        string
+            srun command with options
+        """
+        return " ".join(["srun -N", str(nodes), "-n", str(procs), "-w", str(nodeId), cmd])
+
+    def run_cmd(self, params, nodeId, trial=0):
+        """
+        Creates a srun command from the trial parameters and nodeId.
+        All trials will create a directory EXPXXX/RUNXXX.  The exp dir
+        is configurable at the creation of this class.  The run is given
+        by the trial id.
+
+        Parameters
+        ----------
+
+        params : list
+            A list of tuples containing name, value for the parameters to run
+
+        nodeId : string
+            The name of the node to run on
+
+        trial : int
+            The trial id (given by the study)
+
+        Returns
+        -------
+        string
+            srun command with options
+        """
+        text = f'python exarl/driver --run_id RUN{trial:04d} --experiment_id ' + self.exp
         dash = [("--" + x[0], str(x[1])) for x in params]
         flat_list = [item for sublist in dash for item in sublist]
         text = ' '.join([text, *flat_list])
-        return self.srun_prefix(text, nodeId=node_id) 
+        return self.srun_prefix(text, nodeId)
 
     def parse(self, output):
+        """
+        This parses the output of the srun command returning the reward, time, and total episodes.
+
+        Parameters
+        ----------
+        output : string
+            The output of the srun command
+
+        Returns
+        -------
+        tuple :
+            Rolling reward, total time, total episodes
+        """
         lines = output.split("\n")
-        #print("BEGIN_LINES: \n", lines, "\nEND_LINES", flush=True)
         for line in lines:
-            if "Total Reward:" in line:
-                rolling_reward = line.split(" ")[-1]
-            elif "Maximum elapsed time" in line:
-                time = line.split(" ")[-1]
-            elif "Num eps" in line:
-                #print("LINE: ", line)
-                num_eps = line.split(" ")[2] 
-        try:
-            return (rolling_reward, time, num_eps)
-        except UnboundLocalError:
-            return False
+            if "Total reward =" in line:
+                total_reward = float(line.split(" ")[-1])
+            elif "Final rolling reward =" in line:
+                rolling_reward = float(line.split(" ")[-1])
+            elif "Maximum elapsed time =" in line:
+                time = float(line.split(" ")[-1])
+            elif "Final number of episodes =" in line:
+                num_eps = int(line.split(" ")[-1])
+        return (rolling_reward, total_reward, time, num_eps)
 
     def objective(self, trial):
+        """
+        This is the objection function.  Here we get the suggested trial parameters and pass them along
+        to create a srun command.  We run this command and parse its output.  The node used to run the
+        command is based on the trial number.  We assume that each python threads is running this
+        function (https://github.com/optuna/optuna/blob/1a520bd5daa9ff0af09fb060464bb157f8af891b/optuna/study/_optimize.py#L64).
+        We also assume each trial takes about the same time such that each nodes starts a stride making
+        the trial number good to use as a node offset. Also srun should treat job step allocations "exclusively."
+
+        From https://slurm.schedmd.com/srun.html :
+            This option applies to job and job step allocations, and has two slightly different meanings for each one...
+            The exclusive allocation of CPUs applies to job steps by default, but --exact is NOT the default. In other words,
+            the default behavior is this: job steps will not share CPUs, but job steps will be allocated all CPUs available
+            to the job on all nodes allocated to the steps.
+
+        The function will try to run the srun command and parse the output.  If the parsing fails,
+        we catch the error and print the output and the error.  We still continue on with the study.
+
+        Parameters
+        ----------
+        trial : int
+            Current trial
+
+        Returns
+        -------
+        float :
+            The score of the run trial, or -1 on failure
+        """
         my_node = trial.number % len(self.all_nodes)
         suggestions = []
         for p in self.params:
@@ -89,58 +246,72 @@ class Optimizer:
                     raise Exception("Could not determine hyperparameter type")
             else:
                 suggestions.append((p, trial.suggest_categorical(p, minimum, maximum)))
-        #print("TRIAL_NUMBER: {} NODE: {} VALUES: {}".format(trial.number, my_node, suggestions))
-        #print(suggestions)
-        cmd = command(self.run_cmd(suggestions, node_id=self.all_nodes[my_node]), wait=True)
-        res = self.parse(cmd.out)
-        try: 
-            res = [float(x) for x in res]
-            res = self.objective_func(res)
-            self.log.append([trial.number, max(res, max([x[1] for x in self.log]))])
+        cmd = command(self.run_cmd(suggestions, self.all_nodes[my_node], trial=trial.number), wait=True)
+        try:
+            res = self.objective_func(self.parse(cmd.out))
+            if res != res:
+                raise ValueError("Result is NaN!")
             return res
-        except:
-            print("PARSING ERROR:\n", cmd.out)
-            print("Error: \n", cmd.err, flush=True)
-            self.log.append([trial.number, self.log[-1][1]])
+        except Exception as e:
+            print(e)
+            print("Failed:", cmd.cmd)
+            print("Output:\n", cmd.out)
+            print("Error:\n", cmd.err, flush=True)
+            # JS: We return -1 since we are maximizing!!!
+            return -1
 
 class command:
+    """
+    This class is a wrapper around subprocesses storing its results.
+
+    Attributes
+    ----------
+    cmd : string
+        Command to run
+    sp : subprocess
+        Subprocess handle to wait on
+    out : string
+        stdout of the command
+    err : string
+        stderr of the command
+    """
     def __init__(self, cmd, wait=False):
         self.cmd = cmd
         self.sp = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
-        self.done = False
-        self.ret = None
         self.out = None
         self.err = None
-
         if wait:
             self.wait()
 
     def wait(self):
-        #self.ret = self.sp.wait()
+        """
+        This will wait for the command to finish populating out and err.
+        """
+        # self.ret = self.sp.wait()
         self.out, self.err = self.sp.communicate()
 
-with open("exarl/config/hyper_params.json") as file:
-    js = json.load(file)
-    parameters_from_json = js["parameters"]
-    my_sampler_ = js["sampler"]
-    my_objective_ = js["objective"]
-my_objective = objectives[my_objective_]
-my_sampler = samplers[my_sampler_]
 
-for sampler in samplers:
-    xpoints = []
-    ypoints = []
-    for _ in range(2):
-        op = Optimizer(parameters_from_json, my_objective, samplers[sampler], n_trials=100)
-        res, log = op.optimize()
-        xpoints.append(np.array([x[0] for x in log]))
-        ypoints.append(np.array([x[1] for x in log]))
-    xpoints = np.array(xpoints)
-    ypoints = np.array(ypoints)
-    xpoints = np.mean(xpoints, axis=0)
-    ypoints = np.mean(ypoints, axis=0)
+if __name__ == "__main__":
+    with open(path_to_json) as file:
+        js = json.load(file)
+        parameters_from_json = js["parameters"]
+        my_sampler = js["sampler"]
+        my_objective = js["objective"]
+        n_trials = js["trials"]
 
-    plt.plot(xpoints, ypoints, label=sampler)
-plt.legend()
-plt.savefig("Rolling_rewards.jpeg")
+    if my_sampler == "all":
+        my_samplers = samplers.keys()
+    else:
+        my_samplers = [my_sampler]
 
+    if my_objective == "all":
+        my_objectives = objectives.keys()
+    else:
+        my_objectives = [my_objective]
+
+    for sampler in my_samplers:
+        for objective in my_objectives:
+            op = Optimizer(parameters_from_json, objectives[objective], samplers[sampler], n_trials=n_trials, exp="_".join([sampler, objective]))
+            res = op.optimize()
+            for param in res:
+                print(sampler, objective, param, res[param])

--- a/exarl/driver/hyper-tune.py
+++ b/exarl/driver/hyper-tune.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+#SBATCH --time=48:00:00
+#SBATCH --exclusive
+
+import sys
+import subprocess
+import optuna
+import json
+import numpy as np
+import matplotlib.pyplot as plt
+
+objectives = {
+    "last_rolling_reward": lambda x: x[0],
+    "reward_per_time": lambda x: x[0]/x[1],
+    "reward_per_episode": lambda x: x[0]/x[2]
+}
+
+samplers = {
+    "tpe": optuna.samplers.TPESampler,
+    "random": optuna.samplers.RandomSampler,
+    "cmaes": optuna.samplers.CmaEsSampler,
+    "qmc": optuna.samplers.QMCSampler,
+}
+
+class Optimizer:
+    def __init__(self, params, objective_func, sampler, n_trials=100, eps=30):
+        self.params = params
+        self.objective_func = objective_func
+        self.sampler = sampler
+        self.n_trials = n_trials
+        self.n_episodes = eps
+        self.all_nodes = self.get_nodes()
+        self.log = [[0, 0]] 
+
+    def optimize(self):
+        #print("Python", sys.version, "All Nodes", all_nodes, flush=True)
+        print("STUDY: ", self.sampler, self.n_trials)
+        study = optuna.create_study(direction="maximize", sampler=self.sampler())
+        study.optimize(self.objective, n_trials=self.n_trials, n_jobs=len(self.all_nodes))
+
+        best_params = study.best_params
+        return [(p, best_params[p]) for p in best_params], self.log
+
+    def get_nodes(self):
+        cmd = command("scontrol show hostnames", wait=True)
+        return [x for x in cmd.out.split('\n') if len(x) > 0]
+
+    def srun_prefix(self, cmd, nodeId=None, nodes=1, procs=1):
+        if nodeId:
+            return " ".join(["srun -N", str(nodes), "-n", str(procs), "-w", nodeId, cmd])
+        else:
+            return " ".join(["srun -N", str(nodes), "-n", str(procs), cmd])
+
+    def run_cmd(self, params, node_id=None):
+        text = "python exarl/driver --n_episodes {}".format(self.n_episodes)
+        dash = [("--" + x[0], str(x[1])) for x in params]
+        flat_list = [item for sublist in dash for item in sublist]
+        text = ' '.join([text, *flat_list])
+        return self.srun_prefix(text, nodeId=node_id) 
+
+    def parse(self, output):
+        lines = output.split("\n")
+        #print("BEGIN_LINES: \n", lines, "\nEND_LINES", flush=True)
+        for line in lines:
+            if "Total Reward:" in line:
+                rolling_reward = line.split(" ")[-1]
+            elif "Maximum elapsed time" in line:
+                time = line.split(" ")[-1]
+            elif "Num eps" in line:
+                #print("LINE: ", line)
+                num_eps = line.split(" ")[2] 
+        try:
+            return (rolling_reward, time, num_eps)
+        except UnboundLocalError:
+            return False
+
+    def objective(self, trial):
+        my_node = trial.number % len(self.all_nodes)
+        suggestions = []
+        for p in self.params:
+            if len(self.params[p]) == 2:
+                minimum, maximum = self.params[p]
+                assert type(minimum) == type(maximum), "Minimum and Maximum types should be the same"
+                if type(minimum) == float:
+                    suggestions.append((p, trial.suggest_float(p, minimum, maximum)))
+                elif type(minimum) == int:
+                    suggestions.append((p, trial.suggest_int(p, minimum, maximum)))
+                else:
+                    raise Exception("Could not determine hyperparameter type")
+            else:
+                suggestions.append((p, trial.suggest_categorical(p, minimum, maximum)))
+        #print("TRIAL_NUMBER: {} NODE: {} VALUES: {}".format(trial.number, my_node, suggestions))
+        #print(suggestions)
+        cmd = command(self.run_cmd(suggestions, node_id=self.all_nodes[my_node]), wait=True)
+        res = self.parse(cmd.out)
+        try: 
+            res = [float(x) for x in res]
+            res = self.objective_func(res)
+            self.log.append([trial.number, max(res, max([x[1] for x in self.log]))])
+            return res
+        except:
+            print("PARSING ERROR:\n", cmd.out)
+            print("Error: \n", cmd.err, flush=True)
+            self.log.append([trial.number, self.log[-1][1]])
+
+class command:
+    def __init__(self, cmd, wait=False):
+        self.cmd = cmd
+        self.sp = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        self.done = False
+        self.ret = None
+        self.out = None
+        self.err = None
+
+        if wait:
+            self.wait()
+
+    def wait(self):
+        #self.ret = self.sp.wait()
+        self.out, self.err = self.sp.communicate()
+
+with open("exarl/config/hyper_params.json") as file:
+    js = json.load(file)
+    parameters_from_json = js["parameters"]
+    my_sampler_ = js["sampler"]
+    my_objective_ = js["objective"]
+my_objective = objectives[my_objective_]
+my_sampler = samplers[my_sampler_]
+
+for sampler in samplers:
+    xpoints = []
+    ypoints = []
+    for _ in range(2):
+        op = Optimizer(parameters_from_json, my_objective, samplers[sampler], n_trials=100)
+        res, log = op.optimize()
+        xpoints.append(np.array([x[0] for x in log]))
+        ypoints.append(np.array([x[1] for x in log]))
+    xpoints = np.array(xpoints)
+    ypoints = np.array(ypoints)
+    xpoints = np.mean(xpoints, axis=0)
+    ypoints = np.mean(ypoints, axis=0)
+
+    plt.plot(xpoints, ypoints, label=sampler)
+plt.legend()
+plt.savefig("Rolling_rewards.jpeg")
+

--- a/exarl/envs/env_vault/ExaCartpoleStatic.py
+++ b/exarl/envs/env_vault/ExaCartpoleStatic.py
@@ -26,6 +26,7 @@ import json
 import exarl as erl
 # from envs.env_vault.computePI import computePI as cp
 from exarl.base.comm_base import ExaComm
+from exarl.utils.introspect import introspectTrace
 
 
 def computePI(N, new_comm):
@@ -49,6 +50,7 @@ class ExaCartpoleStatic(gym.Env):
         self.action_space = self.env.action_space
         self.observation_space = self.env.observation_space
 
+    @introspectTrace()
     def step(self, action):
         next_state, reward, done, info = self.env.step(action)
         time.sleep(0)  # Delay in seconds

--- a/exarl/network/typing.py
+++ b/exarl/network/typing.py
@@ -2,7 +2,6 @@ import sys
 import os
 import functools
 import numpy as np
-import tensorflow as tf
 from exarl.base.comm_base import ExaComm
 
 class TypeUtils:
@@ -10,6 +9,9 @@ class TypeUtils:
     This class is a group of commonly used functions that help to figure out what type a data object is
     as well as providing type conversions between numpy, mpi, and python types.
     """
+
+    def tf_to_np(the_type):
+        return the_type
 
     def list_like(data):
         """
@@ -222,111 +224,6 @@ class TypeUtils:
             return False
         return True
 
-    def np_type_converter(the_type, promote=True):
-        """
-        Provides the equivalent numpy type givin python, MPI, tensorflow type.
-
-        Parameters
-        ----------
-        the_type : type
-            type to be converted
-
-        promote : bool, optional
-            promots from 32 to 64 bit precision
-
-        Returns
-        -------
-        type
-            return corresponding np type
-        """
-        MPI = ExaComm.get_MPI()
-        if the_type == float or the_type == np.float64 or the_type == tf.float64 or the_type == MPI.DOUBLE:
-            return np.float64
-        if the_type == np.float32 or the_type == tf.float32 or the_type == MPI.FLOAT:
-            if promote:
-                return np.float64
-            return np.float32
-        if the_type == int or the_type == np.int64 or the_type == tf.int64 or the_type == MPI.INT64_T:
-            return np.int64
-        if the_type == np.int32 or the_type == tf.int32 or the_type == MPI.INT:
-            if promote:
-                return np.int64
-            return np.int32
-        if the_type == bool or the_type == np.bool or the_type == tf.bool or the_type == MPI.BOOL:
-            return np.bool
-        print("Failed to convert type", the_type, "to np type")
-        return the_type
-
-    def tf_type_converter(the_type, promote=True):
-        """
-        Provides the equivalent tensorflow type givin python, MPI, or numpy type.
-
-        Parameters
-        ----------
-        the_type : type
-            type to be converted
-
-        promote : bool, optional
-            promots from 32 to 64 bit precision
-
-        Returns
-        -------
-        type
-            return corresponding tensorflow type
-        """
-        MPI = ExaComm.get_MPI()
-        if the_type == float or the_type == np.float64 or the_type == tf.float64 or the_type == MPI.DOUBLE:
-            return tf.float64
-        if the_type == np.float32 or the_type == tf.float32 or the_type == MPI.FLOAT:
-            if promote:
-                return tf.float64
-            return tf.float32
-        if the_type == int or the_type == np.int64 or the_type == tf.int64 or the_type == MPI.INT64_T:
-            return tf.int64
-        if the_type == np.int32 or the_type == tf.int32 or the_type == MPI.INT:
-            if promote:
-                return tf.int64
-            return tf.int32
-        if the_type == bool or the_type == np.bool or the_type == tf.bool or the_type == MPI.BOOL:
-            return tf.bool
-        print("Failed to convert type", the_type, "to tf type")
-        return the_type
-
-    def mpi_type_converter(the_type, promote=True):
-        """
-        Provides the equivalent MPI type givin python, tensorflow, or numpy type.
-
-        Parameters
-        ----------
-        the_type : type
-            type to be converted
-
-        promote : bool, optional
-            promots from 32 to 64 bit precision
-
-        Returns
-        -------
-        type
-            return corresponding mpi type
-        """
-        MPI = ExaComm.get_MPI()
-        if the_type == float or the_type == np.float64 or the_type == tf.float64 or the_type == MPI.DOUBLE:
-            return MPI.DOUBLE
-        if the_type == np.float32 or the_type == tf.float32 or the_type == MPI.FLOAT:
-            if promote:
-                return MPI.DOUBLE
-            return MPI.FLOAT
-        if the_type == int or the_type == np.int64 or the_type == tf.int64 or the_type == MPI.INT64_T:
-            return MPI.INT64_T
-        if the_type == np.int32 or the_type == tf.int32 or the_type == MPI.INT:
-            if promote:
-                return MPI.INT64_T
-            return MPI.INT
-        if the_type == bool or the_type == np.bool or the_type == tf.bool or the_type == MPI.BOOL:
-            return MPI.BOOL
-        print("Failed to convert type", the_type, "to mpi type")
-        return the_type
-
     def promote_numpy_type(data, makeList=True):
         """
         Turns non-list-like data to a numpy array. Promotes numpy lists from 32 to 64 bit.
@@ -378,3 +275,125 @@ class TypeUtils:
         if val in bool_map:
             return bool_map[val]
         return default
+
+    def np_type_converter(the_type, promote=True):
+        """
+        Provides the equivalent numpy type givin python, MPI, tensorflow type.
+
+        Parameters
+        ----------
+        the_type : type
+            type to be converted
+
+        promote : bool, optional
+            promots from 32 to 64 bit precision
+
+        Returns
+        -------
+        type
+            return corresponding np type
+        """
+        MPI = ExaComm.get_MPI()
+        the_type = TypeUtils.tf_to_np(the_type)
+        if the_type == float or the_type == np.float64 or the_type == MPI.DOUBLE:
+            return np.float64
+        if the_type == np.float32 or the_type == MPI.FLOAT:
+            if promote:
+                return np.float64
+            return np.float32
+        if the_type == int or the_type == np.int64 or the_type == MPI.INT64_T:
+            return np.int64
+        if the_type == np.int32 or the_type == MPI.INT:
+            if promote:
+                return np.int64
+            return np.int32
+        if the_type == bool or the_type == np.bool or the_type == MPI.BOOL:
+            return np.bool
+        print("Failed to convert type", the_type, "to np type")
+        return the_type
+
+    def mpi_type_converter(the_type, promote=True):
+        """
+        Provides the equivalent MPI type givin python, tensorflow, or numpy type.
+
+        Parameters
+        ----------
+        the_type : type
+            type to be converted
+
+        promote : bool, optional
+            promots from 32 to 64 bit precision
+
+        Returns
+        -------
+        type
+            return corresponding mpi type
+        """
+        MPI = ExaComm.get_MPI()
+        the_type = TypeUtils.tf_to_np(the_type)
+        if the_type == float or the_type == np.float64 or the_type == MPI.DOUBLE:
+            return MPI.DOUBLE
+        if the_type == np.float32 or the_type == MPI.FLOAT:
+            if promote:
+                return MPI.DOUBLE
+            return MPI.FLOAT
+        if the_type == int or the_type == np.int64 or the_type == MPI.INT64_T:
+            return MPI.INT64_T
+        if the_type == np.int32 or the_type == MPI.INT:
+            if promote:
+                return MPI.INT64_T
+            return MPI.INT
+        if the_type == bool or the_type == np.bool or the_type == MPI.BOOL:
+            return MPI.BOOL
+        print("Failed to convert type", the_type, "to mpi type")
+        return the_type
+    
+    def tf_type_converter(the_type, promote=True):
+        return the_type
+
+for module in sys.modules:
+    if 'tensorflow' in module:
+        import tensorflow as tf
+        
+        def real_tf_to_np(the_type):
+            converter = {tf.float64 : np.float64, tf.int32 : np.float32, tf.bool : np.bool}
+            if the_type in converter:
+                return converter[the_type]
+
+        def real_tf_type_converter(the_type, promote=True):
+            """
+            Provides the equivalent tensorflow type givin python, MPI, or numpy type.
+
+            Parameters
+            ----------
+            the_type : type
+                type to be converted
+
+            promote : bool, optional
+                promots from 32 to 64 bit precision
+
+            Returns
+            -------
+            type
+                return corresponding tensorflow type
+            """
+            MPI = ExaComm.get_MPI()
+            if the_type == float or the_type == np.float64 or the_type == tf.float64 or the_type == MPI.DOUBLE:
+                return tf.float64
+            if the_type == np.float32 or the_type == tf.float32 or the_type == MPI.FLOAT:
+                if promote:
+                    return tf.float64
+                return tf.float32
+            if the_type == int or the_type == np.int64 or the_type == tf.int64 or the_type == MPI.INT64_T:
+                return tf.int64
+            if the_type == np.int32 or the_type == tf.int32 or the_type == MPI.INT:
+                if promote:
+                    return tf.int64
+                return tf.int32
+            if the_type == bool or the_type == np.bool or the_type == tf.bool or the_type == MPI.BOOL:
+                return tf.bool
+            print("Failed to convert type", the_type, "to tf type")
+            return the_type
+
+        TypeUtils.tf_to_np = real_tf_to_np
+        TypeUtils.tf_type_converter = real_tf_type_converter

--- a/exarl/network/typing.py
+++ b/exarl/network/typing.py
@@ -347,16 +347,17 @@ class TypeUtils:
             return MPI.BOOL
         print("Failed to convert type", the_type, "to mpi type")
         return the_type
-    
+
     def tf_type_converter(the_type, promote=True):
         return the_type
+
 
 for module in sys.modules:
     if 'tensorflow' in module:
         import tensorflow as tf
-        
+
         def real_tf_to_np(the_type):
-            converter = {tf.float64 : np.float64, tf.int32 : np.float32, tf.bool : np.bool}
+            converter = {tf.float64: np.float64, tf.int32: np.float32, tf.bool: np.bool}
             if the_type in converter:
                 return converter[the_type]
 

--- a/exarl/utils/analyze_reward.py
+++ b/exarl/utils/analyze_reward.py
@@ -72,7 +72,7 @@ def save_reward_plot():
     df_merged['rel_time'] = [idx - time_min for idx in df_merged.time]
     df_merged.sort_values(by=['rel_time'], inplace=True)
 
-    rolling_setting = 25
+    rolling_setting = ExaGlobals.lookup_params('plot_rolling_range')
     fig, ax = plt.subplots(1, 1, figsize=(10, 8))
     episodes_per_nodes = []
     df_merged['total_reward_roll'] = df_merged['total_reward'].rolling(rolling_setting).mean()
@@ -101,5 +101,6 @@ def save_reward_plot():
         figure.plot(range(len(df_merged['total_reward_roll'])), df_merged['total_reward_roll'].replace(np.nan, 0), lc=200, label='rolling reward')
         # range(len(df_merged['time']))
         print(figure.show(legend=True))
+        print("Total Reward: ", df_merged.iloc[-1, -1])
     except:
         print("Terminal plot error: Check if you have plotille installed or for other errors.")

--- a/exarl/utils/analyze_reward.py
+++ b/exarl/utils/analyze_reward.py
@@ -72,7 +72,7 @@ def save_reward_plot():
     df_merged['rel_time'] = [idx - time_min for idx in df_merged.time]
     df_merged.sort_values(by=['rel_time'], inplace=True)
 
-    rolling_setting = ExaGlobals.lookup_params('plot_rolling_range')
+    rolling_setting = ExaGlobals.lookup_params('rolling_reward_length')
     fig, ax = plt.subplots(1, 1, figsize=(10, 8))
     episodes_per_nodes = []
     df_merged['total_reward_roll'] = df_merged['total_reward'].rolling(rolling_setting).mean()

--- a/exarl/utils/candleDriver.py
+++ b/exarl/utils/candleDriver.py
@@ -29,18 +29,33 @@ import exarl.candlelib.candle as candle
 file_path = os.path.dirname(os.path.realpath(__file__))
 required = ['agent', 'env', 'workflow', 'model_type']
 
-def resolve_path(*path_components) -> str:
-    """ Resolve path to configuration files.
+def resolve_path(*path_components, config_path=None, alternate_path=None) -> str:
+    """
+    Resolve path to configuration files.  The alternate path is a second choice
+    based on the externally loaded modules.  We look to see if any config files
+    exist in these dirs.  For env and agent files they must still follow the
+    dir structure (i.e. agent_cfg/DQN-v0.json or env_cfg/ExaCartPoleStatic-v0).
     Priority is as follows:
-      1. <current working directory>/exarl/config
-      2. ~/.exarl/config
-      3. <site-packages dir>/exarl/config
+      1. Path passed in at command line using --config_file
+      2. Alternate path given by --load_agent/env_path
+      3. <current working directory>/exarl/config
+      4. ~/.exarl/config
+      5. <site-packages dir>/exarl/config
     """
     if len(path_components) == 1:
         path = path_components[0]
     else:
         path = os.path.join(*path_components)
-
+    if config_path is not None:
+        config_path = os.path.abspath(config_path)
+        config_path = os.path.join(config_path, path)
+        if os.path.exists(config_path):
+            return config_path
+    if alternate_path is not None:
+        alternate_path = os.path.abspath(alternate_path)
+        alternate_path = os.path.join(alternate_path, path)
+        if os.path.exists(alternate_path):
+            return alternate_path
     cwd_path = os.path.join(os.getcwd(), 'exarl', 'config', path)
     if os.path.exists(cwd_path):
         return cwd_path
@@ -76,6 +91,70 @@ def initialize_parameters(params=None):
                                  desc='CANDLE example driver script')
         params = candle.finalize_parameters(driver)
     ExaGlobals(params, candle.keras_default_config())
+
+def config_parser():
+    """
+    This parsers runs first to get a config_path if present.
+    It removes the argument by resetting the sys.argv with the remaining args.
+
+    Returns
+    -------
+    String :
+        The path to search for config file
+    """
+    parser = argparse.ArgumentParser(description="Config parser")
+    parser.add_argument("--config_path")
+    args, leftovers = parser.parse_known_args()
+    if args.config_path is not None and not os.path.exists(args.config_path):
+        raise FileNotFoundError("Path {0} does not exists!".format(args.config_path))
+    sys.argv = sys.argv[:1] + leftovers
+    return args.config_path
+
+def external_env_and_agents_parser():
+    """
+    This checks command line for external agents and envs.  If the load_*_path is
+    set for either, they will by added to the system path.  The load_agent and
+    load_env will be added to the candle params.
+
+    Returns
+    -------
+    List :
+        List of load agent/env params
+    String :
+        agent load path
+    String :
+        env load path
+    """
+    parser = argparse.ArgumentParser(description="External source parser")
+    parser.add_argument("--load_agent_module")
+    parser.add_argument("--load_agent_path")
+    parser.add_argument("--load_env_module")
+    parser.add_argument("--load_env_path")
+    args, leftovers = parser.parse_known_args()
+
+    if args.load_agent_path is not None:
+        args.load_agent_path = os.path.abspath(args.load_agent_path)
+        if not os.path.exists(args.load_agent_path):
+            raise FileNotFoundError("Path {0} does not exists!".format(args.load_agent_path))
+        if args.load_agent_path not in sys.path:
+            sys.path.append(args.load_agent_path)
+
+    if args.load_env_path is not None:
+        args.load_env_path = os.path.abspath(args.load_env_path)
+        if not os.path.exists(args.load_env_path):
+            raise FileNotFoundError("Path {0} does not exists!".format(args.load_env_path))
+        if args.load_env_path not in sys.path:
+            sys.path.append(args.load_env_path)
+
+    ret = []
+    if args.load_agent_module is not None:
+        ret.append({'name': 'load_agent_module', 'type': str, 'default': args.load_agent_module})
+
+    if args.load_env_module is not None:
+        ret.append({'name': 'load_env_module', 'type': str, 'default': args.load_agent_module})
+
+    sys.argv = sys.argv[:1] + leftovers
+    return ret, args.load_agent_module, args.load_env_module
 
 def base_parser(params):
     """
@@ -152,7 +231,7 @@ def parser_from_json(json_file):
 
     return new_defs
 
-def check_keyword_and_config(params, keyword):
+def check_keyword_and_config(params, keyword, config_path, alternate_path=None):
     """
         This function performs a check for specific keywords to see if
         they are set in the config file and also checks if there is a
@@ -164,10 +243,10 @@ def check_keyword_and_config(params, keyword):
         else:
             cfg = keyword + "_cfg"
         try:
-            cfg_file = resolve_path(cfg, params[keyword] + '.json')
+            cfg_file = resolve_path(cfg, params[keyword] + '.json', config_path=config_path, alternate_path=alternate_path)
             print('Agent parameters from ', cfg)
         except FileNotFoundError:
-            cfg_file = resolve_path(cfg, 'default_' + cfg + '.json')
+            cfg_file = resolve_path(cfg, 'default_' + cfg + '.json', config_path=config_path)
             print(keyword + ' configuration does not exist, using default configuration')
         return parser_from_json(cfg_file)
     else:
@@ -180,20 +259,23 @@ def get_driver_params():
         Unless overwritten from the command line (via base_parser), the names for
         these config files are defined in the learner_cfg.json file.
     """
-    learner_cfg = resolve_path('learner_cfg.json')
+    config_path = config_parser()
+    external_defs, load_agent_path, load_env_path = external_env_and_agents_parser()
+
+    learner_cfg = resolve_path('learner_cfg.json', config_path=config_path)
     learner_defs = parser_from_json(learner_cfg)
     print('Learner parameters from ', learner_cfg)
     params = json.load(open(learner_cfg))
     params = base_parser(params)
 
-    agent_defs = check_keyword_and_config(params, "agent")
-    env_defs = check_keyword_and_config(params, "env")
-    workflow_defs = check_keyword_and_config(params, "workflow")
-    model_defs = check_keyword_and_config(params, "model_type")
+    agent_defs = check_keyword_and_config(params, "agent", config_path, alternate_path=load_agent_path)
+    env_defs = check_keyword_and_config(params, "env", config_path, alternate_path=load_env_path)
+    workflow_defs = check_keyword_and_config(params, "workflow", config_path)
+    model_defs = check_keyword_and_config(params, "model_type", config_path)
 
     print('_________________________________________________________________')
     print("Running - {}, {}, {}, and {}".format(params['agent'], params['env'], params['workflow'], params['model_type']))
     # print("Running - {}, {}, {} and {}".format(params['agent'], params['model_type'], params['env'], params['workflow']))
     print('_________________________________________________________________', flush=True)
 
-    return learner_defs + agent_defs + env_defs + workflow_defs + model_defs
+    return learner_defs + agent_defs + env_defs + workflow_defs + model_defs + external_defs

--- a/exarl/utils/candleDriver.py
+++ b/exarl/utils/candleDriver.py
@@ -23,7 +23,6 @@ import sys
 import site
 import json
 import argparse
-from tensorflow import keras
 from exarl.utils.globals import ExaGlobals
 import exarl.candlelib.candle as candle
 

--- a/exarl/workflows/workflow_vault/async_learner.py
+++ b/exarl/workflows/workflow_vault/async_learner.py
@@ -93,7 +93,7 @@ class ASYNC(SYNC):
 
         policy_type : int
             This is the policy given by the actor performing inference to get an action
-        
+
         done : bool
             Indicates if the episode is competed
 
@@ -155,7 +155,7 @@ class ASYNC(SYNC):
             while self.alive > 0 and self.done_episode < nepisodes:
                 do_convergence_check = self.learner(workflow, nepisodes, 1)
                 if do_convergence_check:
-                    convergence = self.check_convergence(nepisodes)
+                    convergence = self.check_convergence()
                 # self.debug("Learner:", self.done_episode, nepisodes, do_convergence_check, convergence)
         else:
             keep_running = True

--- a/exarl/workflows/workflow_vault/async_learner.py
+++ b/exarl/workflows/workflow_vault/async_learner.py
@@ -25,7 +25,7 @@ from exarl.utils.profile import PROFILE
 class ASYNC(SYNC):
     """
     This class builds ontop of the simple learner to support processing
-    environments in parallel.  This is achieved by having separate leaners
+    environments in parallel.  This is achieved by having separate learners
     and actors.  The communication is performed by MPI sends/recvs.
 
     We are currently supporting single learner thus we set block_size = 2
@@ -93,6 +93,16 @@ class ASYNC(SYNC):
 
         policy_type : int
             This is the policy given by the actor performing inference to get an action
+        
+        done : bool
+            Indicates if the episode is competed
+
+        epsilon : float
+            Current epsilon value to send to learner
+
+        episode_reward : float
+            The total reward from the last episode.  If the episode in not done, it
+            will be the current total reward.
         """
         ExaComm.agent_comm.send([ExaComm.agent_comm.rank, batch_data, policy_type, done, epsilon, episode_reward], 0)
 

--- a/exarl/workflows/workflow_vault/async_learner.py
+++ b/exarl/workflows/workflow_vault/async_learner.py
@@ -138,7 +138,7 @@ class ASYNC(SYNC):
         """
         convergence = -1
         nepisodes = self.episode_round(workflow)
-        
+
         # These are the loops used to keep everyone running
         if ExaComm.is_learner():
             self.init_learner(workflow)

--- a/exarl/workflows/workflow_vault/sync_learner.py
+++ b/exarl/workflows/workflow_vault/sync_learner.py
@@ -37,11 +37,14 @@ class SYNC(exarl.ExaWorkflow):
     Agents - the ranks responsible for training/inference.  Agents include learners.
     Actors - everyone that is not a learner.
 
+    In addition to this there is the environment comm which includes an agent and
+    actors.
+
     The following is an example useful for understanding the above descriptions.
     The example assumes 14 ranks (2 Learners, 5 Agents, 4 Environment)
     We present both the comms and the ranks.
     There is no actor comm so we add * to depict actors.
-    Rank  0  1  2  3  4  5  6  7  8  9  10 11 12 13
+    Rank   0  1  2  3  4  5  6  7  8  9  10 11 12 13 14
     Learn     0  1  -  -  -  -  -  -  -  -  -  -  -  -
     Agent     0  1  2  -  -  -  3  -  -  -  4  -  -  -
     Actor     -  -  *  *  *  *  *  *  *  *  *  *  *  *
@@ -49,11 +52,21 @@ class SYNC(exarl.ExaWorkflow):
 
     For a single rank execution, global rank 0 is the learner, agent, and environment.
 
-    The cut-off condition for this is based on how many episodes the
-    done learner observes.  We have two sets of internal variables
-    one set used by the learners and another used by the actors.
-    Batches and weights are passed via the leaner and actor calls by
-    setting self.batch and self.weights.
+    There are two possible cut-off conditions that this workflow respects:
+
+    1. The first cut-off condition for this is based on how many completed (done)
+    episodes the learner observes.
+
+    2. The second is based on learning convergence.  This is configured via the config
+    files using the rolling reward length and cutoff settings.  We determine if we
+    have converged by looking at the rolling average of the absolute value of the
+    differences across the last N number of episodes.  If this value is <= the config
+    cutoff value, we terminate execution.  To turn the cutoff off
+    set the cutoff configuration to -1.
+    
+    We have two sets of internal variables one set used by the learners and another
+    used by the actors. Batches and weights are passed via the leaner and actor calls
+    by setting self.batch and self.weights.
 
     We maintain a distinction between learner and agent variables even in the single
     rank such that this can serve as a base class for future workflows.  The actor
@@ -74,10 +87,24 @@ class SYNC(exarl.ExaWorkflow):
         the value to one.  For sequential learning this
         is set to one.
 
-    batch_frequency : int
+    batch_step_frequency : int
         This value is used to determine how often we should
-        send a batch of data.  The value represents performing
-        batch_frequency steps per 1 batch send.
+        send a batch of data within an episode.  The value
+        represents performing batch_step_frequency steps 
+        per 1 batch send.
+
+    batch_episode_frequency : int
+        This indicates how many episodes an actor should run before sending
+        its results to the learner.  This features is required by sum learning
+        algorithms (i.e. rollout).
+
+    log_frequency : int
+        This indicates how often we should write to the log.  Logging
+        can be costly in time.
+
+    clip_rewards : list
+        This variable indicates if rewards should be clipped to a space
+        of -1 to 1.
 
     next_episode : int
         This value is used by the learner to keep track of
@@ -103,6 +130,10 @@ class SYNC(exarl.ExaWorkflow):
         This flag indicates if the episode is done.
         This is used by the actor.
 
+    current_state : 
+        This is the current state of an environment for
+        a given actor.
+
     model_count : int
         This is the current generation of the model.  This counter
         is set on the learner.  It is up to the send/recv to
@@ -124,8 +155,26 @@ class SYNC(exarl.ExaWorkflow):
     episode_reward_list : list
         This store total reward at the end of an episode.
 
+    cutoff : float
+        This is the minimum value of absolute difference between the
+        last rolling_reward_length episodes required to consider
+        learning to have converged.  Set to -1 to turn off the
+        convergence cutoff.
+    
+    rolling_reward_length :
+        The last number of episodes to consider to a 
+        rolling average reward 
+
+    converged : bool
+        Indicates if learning convergence has been reached
+
+    alive : 
+        Counter of the number of actors that have not finished.
+
     verbose : bool
         Debug print flag
+
+    
     """
     verbose = False
 
@@ -245,16 +294,20 @@ class SYNC(exarl.ExaWorkflow):
         total_reward : float
             This is the cumulative reward for within an episode
 
+        done : bool
+            Flag indicated the episode ended
+        
+        episode : int
+            Current episode to log
+
         steps : int
             This is the current step within an episode
 
         policy_type : int
-            This value is given by the action...
-            TODO: Make this comment better
+            This value is given by the action.
 
         epsilon : float
-            The current value for given agent...
-            TODO: Make this comment better
+            The current value of epsilon
         """
         if ExaComm.is_agent():
             self.data_matrix.append([time.time(), current_state, action, reward, next_state, total_reward, done, episode, steps, policy_type, epsilon])
@@ -305,7 +358,7 @@ class SYNC(exarl.ExaWorkflow):
             This contains the agent and env
 
         episode : int
-            The current episode curresponding to the model generation
+            The current episode corresponding to the model generation
 
         train_return : list
             This is what comes out of the learner calling train to be sent back
@@ -324,7 +377,7 @@ class SYNC(exarl.ExaWorkflow):
         """
         This function is the corresponding receive function to
         the send_model function.  Here the weights are being received by the
-        the other agents (sent from the learner).  Again for the sync learner
+        the other agents (sent from the learner).  For the sync learner
         we retrieve this data which is stored locally, however this function is
         to be overloaded for more interesting workflows.
 
@@ -351,7 +404,16 @@ class SYNC(exarl.ExaWorkflow):
 
         policy_type : int
             This is the policy given by the actor performing inference to get an action
-            TODO: Make this description better
+
+        done : bool
+            Indicates if the episode is competed
+
+        epsilon : float
+            Current epsilon value to send to learner
+
+        episode_reward : float
+            The total reward from the last episode.  If the episode in not done, it
+            will be the current total reward.
         """
         self.batch = [ExaComm.agent_comm.rank, batch_data, policy_type, done, epsilon, episode_reward]
 
@@ -407,6 +469,9 @@ class SYNC(exarl.ExaWorkflow):
         multi-agent case which should iterate over the agent comm and update
         the episode_per_rank[i] where i is the agent_comm.rank.
 
+        The alive variable is used to know how many actors are still running.
+        This is important when a cutoff or number of done episodes is reached.
+
         Parameters
         ----------
         exalearner : ExaLearner
@@ -418,15 +483,25 @@ class SYNC(exarl.ExaWorkflow):
             self.send_model(exalearner, self.next_episode, None, 0)
             self.next_episode += self.batch_episode_frequency
             self.alive += 1
-
-    def get_rolling_reward(self):
-        return np.mean(np.abs(np.diff(np.array(self.episode_reward_list[-self.rolling_reward_length:])))), self.rolling_reward_length
     
     def check_convergence(self):
+        """
+        This function checks if our learning performance has converged.
+        We consider this to converge if the past N episodes and an average 
+        absolute difference less than some configurable cutoff.  To use the
+        convergence check, set the rolling_reward_length > 1 (config variable)
+        and set the desired minimum via cutoff configuration variable.  To
+        turn off set the cutoff to -1.
+
+        Returns
+        -------
+        float :
+            The average absolute difference if checking for convergence, -1 otherwise
+        """
         # Lets us know how we are doing
         if self.cutoff > 0 and self.rolling_reward_length > 1 and not self.converged:
             if len(self.episode_reward_list) >= self.rolling_reward_length:
-                ave, _ = self.get_rolling_reward()
+                ave = np.mean(np.abs(np.diff(np.array(self.episode_reward_list[-self.rolling_reward_length:]))))
                 if ave < self.cutoff:
                     self.converged = True
                     print("Converged:", len(self.episode_reward_list), "Alive:", self.alive, "Ave:", ave, "Last:", self.episode_reward_list[-1])
@@ -445,7 +520,7 @@ class SYNC(exarl.ExaWorkflow):
         4. Sends data back to the appropriate actors
 
         Each call to train/target train represents a new model
-        generation.  On-policy learning is means that the experiences
+        generation.  On-policy learning means that the experiences
         contained by the batch are from the previous model (i.e.
         there is only one generation of models between them).
         Off-policy learning is done when experiences are used from
@@ -454,7 +529,8 @@ class SYNC(exarl.ExaWorkflow):
         scale to use multiple actors we will by definition be
         training with older models.  If we were to collect data
         from each actor round robin with N actors, the model would
-        be off policy by N models.
+        be off policy by N models.  This assumes we collect the
+        experiences from each actor and train one at a time.
 
         The block_size variable is to approximate on-policy learning
         with multiple actors.  By setting block_size to the number of
@@ -607,7 +683,7 @@ class SYNC(exarl.ExaWorkflow):
                 next_state, reward, self.done, _ = exalearner.env.step(action)
                 self.steps += 1
 
-                # Clip rewards if specified
+                # Clip rewards if specified in configuration
                 if self.clip_rewards is not None:
                     reward = max(min(reward, self.clip_rewards[1]), self.clip_rewards[0])
 
@@ -639,10 +715,6 @@ class SYNC(exarl.ExaWorkflow):
         Rounds to an even number of episodes for blocking purposes.
         We broadcast this result to everyone.  This is also a good
         sync point prior to running loops.
-
-        This function also adds the members workflow_episode and
-        workflow_step to the environment for environments who
-        want to keep track of the current episode/step.
 
         Parameters
         ----------
@@ -705,7 +777,34 @@ class SYNC(exarl.ExaWorkflow):
                 self.debug("Actor:", keep_running)
 
     def get_total_episodes_run(self):
+        """
+        The number of episodes finished.  This is important especially when using convergence cutoff.
+        
+        Returns
+        -------
+        int :
+            Total number of episodes completed
+        """
         return self.done_episode
 
     def get_total_reward(self):
+        """
+        Gives the sum of the rewards across episodes
+        
+        Returns
+        -------
+        int :
+            Total reward across learning from all episodes
+        """
         return sum(self.episode_reward_list)
+
+    def get_rolling_reward(self):
+        """
+        Gives the rolling reward based on the configuration variable rolling_reward_length
+        
+        Returns
+        -------
+        int :
+            Average reward of the rolling_reward_length number of episodes.
+        """
+        return np.mean(np.array(self.episode_reward_list[-self.rolling_reward_length:])), self.rolling_reward_length

--- a/exarl/workflows/workflow_vault/sync_learner.py
+++ b/exarl/workflows/workflow_vault/sync_learner.py
@@ -63,7 +63,7 @@ class SYNC(exarl.ExaWorkflow):
     differences across the last N number of episodes.  If this value is <= the config
     cutoff value, we terminate execution.  To turn the cutoff off
     set the cutoff configuration to -1.
-    
+
     We have two sets of internal variables one set used by the learners and another
     used by the actors. Batches and weights are passed via the leaner and actor calls
     by setting self.batch and self.weights.
@@ -90,7 +90,7 @@ class SYNC(exarl.ExaWorkflow):
     batch_step_frequency : int
         This value is used to determine how often we should
         send a batch of data within an episode.  The value
-        represents performing batch_step_frequency steps 
+        represents performing batch_step_frequency steps
         per 1 batch send.
 
     batch_episode_frequency : int
@@ -130,7 +130,7 @@ class SYNC(exarl.ExaWorkflow):
         This flag indicates if the episode is done.
         This is used by the actor.
 
-    current_state : 
+    current_state :
         This is the current state of an environment for
         a given actor.
 
@@ -160,21 +160,21 @@ class SYNC(exarl.ExaWorkflow):
         last rolling_reward_length episodes required to consider
         learning to have converged.  Set to -1 to turn off the
         convergence cutoff.
-    
+
     rolling_reward_length :
-        The last number of episodes to consider to a 
-        rolling average reward 
+        The last number of episodes to consider to a
+        rolling average reward
 
     converged : bool
         Indicates if learning convergence has been reached
 
-    alive : 
+    alive :
         Counter of the number of actors that have not finished.
 
     verbose : bool
         Debug print flag
 
-    
+
     """
     verbose = False
 
@@ -296,7 +296,7 @@ class SYNC(exarl.ExaWorkflow):
 
         done : bool
             Flag indicated the episode ended
-        
+
         episode : int
             Current episode to log
 
@@ -316,7 +316,6 @@ class SYNC(exarl.ExaWorkflow):
                     self.train_writer.writerows(self.data_matrix)
                     self.train_file.flush()
                     self.data_matrix = []
-
 
     def save_weights(self, exalearner, episode, nepisodes):
         """
@@ -483,11 +482,11 @@ class SYNC(exarl.ExaWorkflow):
             self.send_model(exalearner, self.next_episode, None, 0)
             self.next_episode += self.batch_episode_frequency
             self.alive += 1
-    
+
     def check_convergence(self):
         """
         This function checks if our learning performance has converged.
-        We consider this to converge if the past N episodes and an average 
+        We consider this to converge if the past N episodes and an average
         absolute difference less than some configurable cutoff.  To use the
         convergence check, set the rolling_reward_length > 1 (config variable)
         and set the desired minimum via cutoff configuration variable.  To
@@ -779,7 +778,7 @@ class SYNC(exarl.ExaWorkflow):
     def get_total_episodes_run(self):
         """
         The number of episodes finished.  This is important especially when using convergence cutoff.
-        
+
         Returns
         -------
         int :
@@ -790,7 +789,7 @@ class SYNC(exarl.ExaWorkflow):
     def get_total_reward(self):
         """
         Gives the sum of the rewards across episodes
-        
+
         Returns
         -------
         int :
@@ -801,7 +800,7 @@ class SYNC(exarl.ExaWorkflow):
     def get_rolling_reward(self):
         """
         Gives the rolling reward based on the configuration variable rolling_reward_length
-        
+
         Returns
         -------
         int :


### PR DESCRIPTION
This pull request has several changes that have been developed over the last quarter. I anticipate this will require a few eyes to test things out.  Some comments on changes here:

- [Issue 162](https://github.com/exalearn/EXARL/issues/162) - There are changes to the workflows to address convergence cutoffs.  These are configurable by new options in the configuration files (cutoff and rolling_reward_length).  These can be used to specify a minimum change in average total reward over the last N steps
- [Issue 166](https://github.com/exalearn/EXARL/issues/166) and [Issue 232](https://github.com/exalearn/EXARL/issues/232) - The step count in the workflows (sync and async) was across two variables and had a off by one counting issue.  We moved this to just one variable and placed it where it is intentionally.
- Fixed the results directory - We noticed some weird overwriting or including old data in rolling reward plots across runs.  This is because the log/results are always stored in EXP001/RUN001.  We have fixed it so we increment the run directory.
- Tensorflow and Pytorch - We made sure the code can run with both Tensorflow and Pytorch.  This required some changes to make sure that Tensorflow isn't loaded when we want Pytorch.  To use pytorch, we change the imports in the main driver.  Currently our repo does not have any Pytorch code...
- We have added a hyper-parameter tuning script.  This requires Optuna and sbatch.  Optuna can run tests in parallel and we use sbatch to do this.  This could be extended further for other schedulers.
- Other quality of life updates.  There were some spelling errors and options missed in the bsuite related scripts.

I am sure this is not 100% ready to merge, but I want to get people looking at it sooner rather than later.