### PR TITLE
Added the capability to do n-step DDPG-v0 and TD3-v1

### DIFF
--- a/exarl/agents/agent_vault/ddpg.py
+++ b/exarl/agents/agent_vault/ddpg.py
@@ -25,6 +25,7 @@ from copy import deepcopy
 import exarl
 from exarl.utils.globals import ExaGlobals
 from exarl.agents.replay_buffers.buffer import Buffer
+from exarl.agents.replay_buffers.nStep_buffer import nStepBuffer
 from exarl.utils.OUActionNoise import OUActionNoise
 from exarl.agents.models.tf_model import Tensorflow_Model
 from exarl.utils.introspect import introspectTrace
@@ -59,7 +60,12 @@ class DDPG(exarl.ExaAgent):
         self.ou_noise = OUActionNoise(mean=np.zeros(1), std_deviation=np.array([0.2]))
 
         # Experience data
-        self._replay = Buffer.create(observation_space=env.observation_space, action_space=env.action_space)
+        self.horizon    = ExaGlobals.lookup_params('horizon')
+        assert self.horizon >= 1, "Invalid Horizon Value: " + str(self.horizon)
+        if self.horizon == 1:
+            self._replay = Buffer.create(observation_space=env.observation_space, action_space=env.action_space)
+        else:
+            self._replay = nStepBuffer(ExaGlobals.lookup_params('buffer_capacity'), self.horizon, self.gamma, observation_space=env.observation_space, action_space=env.action_space)
 
         self.actor = Tensorflow_Model.create("Actor", 
                                               observation_space=env.observation_space, 

--- a/exarl/agents/agent_vault/keras_td3.py
+++ b/exarl/agents/agent_vault/keras_td3.py
@@ -33,6 +33,7 @@ from tensorflow.keras.optimizers import Adam
 import exarl
 from exarl.utils.globals import ExaGlobals
 from exarl.agents.replay_buffers.replay_buffer import ReplayBuffer
+from exarl.agents.replay_buffers.nStep_buffer  import nStepBuffer
 logger = ExaGlobals.setup_logger(__name__)
 
 from exarl.agents.models.tf_model import Tensorflow_Model
@@ -55,16 +56,22 @@ class KerasTD3(exarl.ExaAgent):
         print('upper_bound: ', self.upper_bound)
         print('lower_bound: ', self.lower_bound)
 
+        # Used to update target networks
+        self.tau = ExaGlobals.lookup_params('tau')
+        self.gamma = ExaGlobals.lookup_params('gamma')
+
         # Buffer
         self.buffer_counter = 0
         self.buffer_capacity = ExaGlobals.lookup_params('buffer_capacity')
         self.batch_size = ExaGlobals.lookup_params('batch_size')
-        self.memory = ReplayBuffer(self.buffer_capacity, env.observation_space, env.action_space)
+        self.horizon    = ExaGlobals.lookup_params('horizon')
         self.per_buffer = np.ones((self.buffer_capacity, 1))
-
-        # Used to update target networks
-        self.tau = ExaGlobals.lookup_params('tau')
-        self.gamma = ExaGlobals.lookup_params('gamma')
+        assert self.horizon >= 1, "Invalid Horizon Value: " + str(self.horizon)
+        print("HORIZON: ",self.horizon)
+        if self.horizon == 1:
+            self.memory = ReplayBuffer(self.buffer_capacity, env.observation_space, env.action_space)
+        else:
+            self.memory = nStepBuffer(self.buffer_capacity, self.horizon, self.gamma, observation_space=env.observation_space, action_space=env.action_space)
 
         # Setup Optimizers
         critic_lr = ExaGlobals.lookup_params('critic_lr')

--- a/exarl/agents/replay_buffers/nStep_buffer.py
+++ b/exarl/agents/replay_buffers/nStep_buffer.py
@@ -1,0 +1,62 @@
+import numpy as np
+from exarl.agents.replay_buffers.replay_buffer import ReplayBuffer
+# np.random.seed(0)
+
+class nStepBuffer(ReplayBuffer):
+    """ 
+    Class implements a simple replay buffer
+    """
+
+    def __init__(self, capacity, horizon, gamma, observation_space=None, action_space=None, name="nStep"):
+        """ 
+        Replay buffer constructor
+
+        Parameters
+        ----------
+        capacity : int
+            Maximum buffer length
+        observation_space : gym space (optional)
+            Sample of observation space used to init buffer
+        action_space : gym space (optional)
+            Sample of action space used to init buffer
+        """
+        super(nStepBuffer, self).__init__(capacity, observation_space=observation_space, action_space=action_space, name=name)
+        self.horizon = horizon
+        self.gamma   = gamma
+
+    def get_data_from_indices(self, indices):
+        """
+        Returns a list of the of data at given indices
+        """
+        assert self._data is not None, str(self) + " -- not initialized!"
+        return_list = []
+        # Append states
+        return_list.append(self._data[0][indices])
+
+        # Append actions
+        return_list.append(self._data[1][indices])
+
+        # Calculate nStep rewards, next states, and done indicators
+        reward_batch   = []
+        done_batch     = []
+        next_state_ind = []
+        for b_start in indices:
+            b_end     = np.min([self._count-1, b_start + self.horizon - 1])
+            done_ind  = np.where(self._data[4][np.arange(b_start, b_end+1) % self._capacity])[0]
+            b_end     = b_end if len(done_ind) == 0 else np.arange(b_start, b_end+1)[done_ind[0]]
+
+            reward_batch.append( np.sum(self._data[2][np.arange(b_start,b_end+1) % self._capacity,0] * self.gamma**np.arange(b_end - b_start + 1)) )
+            next_state_ind.append( b_end % self._capacity)
+            done_batch.append( 0 if len(done_ind) == 0 else 1)
+
+        # Append nStep rewards
+        return_list.append(np.array(reward_batch)[:,None])
+        
+        # Append nStep next state
+        return_list.append(self._data[3][next_state_ind])
+
+        # Append nStep done indicators
+        return_list.append(np.array(done_batch))
+
+        return return_list
+

--- a/exarl/candlelib/default_utils.py
+++ b/exarl/candlelib/default_utils.py
@@ -475,6 +475,8 @@ def get_common_parser(parser):
 
     parser.add_argument("--run_id", default=argparse.SUPPRESS, type=str, help="set the run unique identifier")
 
+    parser.add_argument("--horizon", default=1, type=int, help="nStep buffer hoizon for DDPG and TD3 Calculations")
+
     # Model definition
     # Model Architecture
     parser.add_argument(


### PR DESCRIPTION
Added the n-step capability from "The Effect of Multi-step Methods on Overestimation in Deep Reinforcement Learning" (https://arxiv.org/abs/2006.12692) to hopefully add flexibility to approve performance. 

Adds a new argument "horizon" to dictate the n-step look-ahead horizon. This defaults to 1, which retains the current behavior of DDPG and TD3. Increasing horizon to integers > 1 will use the new nStepBuffer. The performance has been tested on Pendulum to ensure that nothing is broken, but any improvement in performance on other problems has not been tested/demonstrated.