### PR TITLE
Update ddpg.py

### DIFF
--- a/exarl/agents/agent_vault/ddpg.py
+++ b/exarl/agents/agent_vault/ddpg.py
@@ -56,7 +56,7 @@ class DDPG(exarl.ExaAgent):
         self.batch_size = ExaGlobals.lookup_params('batch_size')
 
         # Ornstein-Uhlenbeck process
-        self.ou_noise = OUActionNoise(mean=np.zeros(1), std_deviation=np.array([0.2]))
+        self.ou_noise = OUActionNoise(mean=np.zeros(env.action_space.shape), std_deviation=np.array([0.2]))
 
         # Experience data
         self._replay = Buffer.create(observation_space=env.observation_space, action_space=env.action_space)


### PR DESCRIPTION
The OUNoise call only works for a scalar action. Currently the noise is a scalar, so if the action space is bigger, it adds the same value to all actions. 

This fix ensures that the OUNoise matches the shape of the action space.