### PR TITLE
Fixing a shape issue in TD3. In train_critic, 

### DIFF
--- a/exarl/agents/agent_vault/keras_td3.py
+++ b/exarl/agents/agent_vault/keras_td3.py
@@ -128,7 +128,7 @@ class KerasTD3(exarl.ExaAgent):
     def train_critic(self, states, actions, rewards, next_states, dones):
         next_actions = self.target_actor(next_states, training=False)
         # Add a little noise
-        noise = np.random.normal(0, 0.2, self.num_actions)
+        noise = np.random.normal(0, 0.2, next_actions.shape)
         noise = np.clip(noise, -0.5, 0.5)
         next_actions = next_actions * (1 + noise)
         new_q1 = self.target_critic1([next_states, next_actions], training=False)
@@ -254,7 +254,7 @@ class KerasTD3(exarl.ExaAgent):
         """ Method used to provide the next action using the target model """
         tf_state = tf.expand_dims(tf.convert_to_tensor(state), 0)
         sampled_actions = tf.squeeze(self.actor(tf_state))
-        noise = np.random.normal(0, 0.1, self.num_actions)
+        noise = np.random.normal(0, 0.1, sampled_actions.shape)
         sampled_actions = sampled_actions.numpy() * (1 + noise)
         policy_type = 1
 


### PR DESCRIPTION
next_actions is (batch_size x self.num_actions), but the noise being sampled was only a self.num_actions length vector. So the same sampled noise was being added to each next_action in a batch. This fixes it. I also changed the noise shape in the action method as well. This one was currently fine, but ensuring it is the shape of sampled_actions ensures that it is the right shape. Having it as a self.num_actions vector could make it not robust to future changes of action space shape.

This is a very small change that I have tested before, but didn't actually get to test on this version because of a gym version issue on my current laptop. 