### PR TITLE
Adding Soft-Actor Critic method to the fixBroken branch

### DIFF
--- a/exarl/agents/__init__.py
+++ b/exarl/agents/__init__.py
@@ -30,6 +30,16 @@ elif agent == 'DDPG-VTRACE-v0':
         id=agent,
         entry_point='exarl.agents.agent_vault:DDPG_Vtrace'
     )
+elif agent == 'SAC-v0':
+    register(
+        id=agent,
+        entry_point='exarl.agents.agent_vault:SAC'
+    )
+elif agent == 'SAC-v1':
+    register(
+        id=agent,
+        entry_point='exarl.agents.agent_vault:SAC_squash'
+    )
 elif agent == 'TD3-v0':
     register(
         id=agent,

--- a/exarl/agents/agent_vault/__init__.py
+++ b/exarl/agents/agent_vault/__init__.py
@@ -14,6 +14,10 @@ elif agent == 'DDPG-v0':
     from exarl.agents.agent_vault.ddpg import DDPG
 elif agent == 'DDPG-VTRACE-v0':
     from exarl.agents.agent_vault.ddpg_vtrace import DDPG_Vtrace
+elif agent == 'SAC-v0':
+    from exarl.agents.agent_vault.keras_sac import SAC
+elif agent == 'SAC-v1':
+    from exarl.agents.agent_vault.keras_sac import SAC_squash
 elif agent == 'TD3-v0':
     from exarl.agents.agent_vault.td3 import TD3
 elif agent == 'TD3-v1':

--- a/exarl/agents/agent_vault/keras_sac.py
+++ b/exarl/agents/agent_vault/keras_sac.py
@@ -1,0 +1,358 @@
+# Copyright (c) 2020, Jefferson Science Associates, LLC. All Rights Reserved. Redistribution
+# and use in source and binary forms, with or without modification, are permitted as a
+# licensed user provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice, this
+#    list of conditions and the following disclaimer in the documentation and/or other
+#    materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# This material resulted from work developed under a United States Government Contract.
+# The Government retains a paid-up, nonexclusive, irrevocable worldwide license in such
+# copyrighted data to reproduce, distribute copies to the public, prepare derivative works,
+# perform publicly and display publicly and to permit others to do so.
+#
+# THIS SOFTWARE IS PROVIDED BY JEFFERSON SCIENCE ASSOCIATES LLC "AS IS" AND ANY EXPRESS
+# OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+# JEFFERSON SCIENCE ASSOCIATES, LLC OR THE U.S. GOVERNMENT BE LIABLE TO LICENSEE OR ANY
+# THIRD PARTES FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import numpy as np
+import tensorflow as tf
+import tensorflow_probability as tfp
+from tensorflow.keras.initializers import RandomUniform
+from tensorflow.keras.optimizers import Adam
+
+import exarl
+from exarl.utils.globals import ExaGlobals
+from exarl.agents.replay_buffers.replay_buffer import ReplayBuffer
+logger = ExaGlobals.setup_logger(__name__)
+
+from exarl.agents.models.tf_model import Tensorflow_Model
+from copy import deepcopy
+
+class SAC(exarl.ExaAgent):
+
+    def __init__(self, env, is_learner, **kwargs):
+        """ Define all key variables required for all agent """
+
+        self.is_learner = is_learner
+        # Get env info
+        super().__init__(**kwargs)
+        self.env = env
+
+        self.num_states = env.observation_space.shape[0]
+        self.num_actions = env.action_space.shape[0]
+        self.upper_bound = env.action_space.high
+        self.lower_bound = env.action_space.low
+        print('upper_bound: ', self.upper_bound)
+        print('lower_bound: ', self.lower_bound)
+
+        # Buffer
+        self.buffer_counter = 0
+        self.buffer_capacity = ExaGlobals.lookup_params('buffer_capacity')
+        self.batch_size = ExaGlobals.lookup_params('batch_size')
+        self.memory = ReplayBuffer(self.buffer_capacity, env.observation_space, env.action_space)
+        self.per_buffer = np.ones((self.buffer_capacity, 1))
+
+        # Used to update target networks
+        self.tau   = ExaGlobals.lookup_params('tau')
+        self.gamma = ExaGlobals.lookup_params('gamma')
+        self.alpha = ExaGlobals.lookup_params('sac_alpha')
+        
+
+        # Setup Optimizers
+        critic_lr = ExaGlobals.lookup_params('critic_lr')
+        actor_lr = ExaGlobals.lookup_params('actor_lr')
+        self.critic_optimizer1 = Adam(critic_lr, epsilon=1e-08)
+        self.critic_optimizer2 = Adam(critic_lr, epsilon=1e-08)
+        self.actor_optimizer = Adam(actor_lr, epsilon=1e-08)
+
+        self.hidden_size = 56
+        self.layer_std = 1.0 / np.sqrt(float(self.hidden_size))
+
+        # # Setup models
+        self.actor  = Tensorflow_Model.create("SoftActor",
+                                              observation_space=env.observation_space,
+                                              action_space=env.action_space,
+                                              use_gpu=self.is_learner)
+        self.critic1 = Tensorflow_Model.create("SoftCritic",
+                                              observation_space=env.observation_space,
+                                              action_space=env.action_space,
+                                              use_gpu=self.is_learner)
+        self.critic2 = Tensorflow_Model.create("SoftCritic",
+                                              observation_space=env.observation_space,
+                                              action_space=env.action_space,
+                                              use_gpu=self.is_learner)
+        self.target_actor   = deepcopy(self.actor)
+        self.target_critic1 = deepcopy(self.critic1)
+        self.target_critic2 = deepcopy(self.critic2)
+
+        self.actor.init_model()
+        self.critic1.init_model()
+        self.critic2.init_model()
+        self.actor.print()
+        self.critic1.print()
+        self.target_actor.init_model()
+        self.target_critic1.init_model()
+        self.target_critic2.init_model()
+
+        self.target_actor.set_weights(self.actor.get_weights())
+        self.target_critic1.set_weights(self.critic1.get_weights())
+        self.target_critic2.set_weights(self.critic2.get_weights())
+
+
+        # update counting
+        self.ntrain_calls = 0
+        self.actor_update_freq = 2
+        self.critic_update_freq = 1
+        self.target_update_freq = 2
+
+        # Not used by agent but required by the learner class
+        # self.epsilon = ExaGlobals.lookup_params('epsilon')
+        # self.epsilon_min = ExaGlobals.lookup_params('epsilon_min')
+        # self.epsilon_decay = ExaGlobals.lookup_params('epsilon_decay')
+
+        logger().info("TD3 buffer capacity {}".format(self.buffer_capacity))
+        logger().info("TD3 batch size {}".format(self.batch_size))
+        logger().info("TD3 tau {}".format(self.tau))
+        logger().info("TD3 gamma {}".format(self.gamma))
+        logger().info("TD3 critic_lr {}".format(critic_lr))
+        logger().info("TD3 actor_lr {}".format(actor_lr))
+
+    @tf.function
+    def train_critic(self, states, actions, rewards, next_states, dones):
+        # next_actions, _ = self.action(next_states, use_target=True)
+
+        sampled_means, sampled_sds = self.actor(next_states)
+        # dist         = tfp.distributions.Normal(sampled_means, sampled_sds)
+        dist         = tfp.distributions.TruncatedNormal(sampled_means, sampled_sds, self.lower_bound, self.upper_bound)
+        next_actions = dist.sample()
+        # next_actions = tf.clip_by_value(next_actions, self.lower_bound, self.upper_bound)
+        # tf.print("Means: ", sampled_means)
+        # tf.print("SDs: ", sampled_sds)
+        next_lp      = tf.reduce_sum(dist.log_prob(next_actions), axis=1)
+        # tf.print("Next Actions: ", next_actions)
+        # tf.print("Log Prob: ", next_lp)
+
+        # Add a little noise
+        new_q1 = self.target_critic1([next_states, next_actions], training=False)
+        new_q2 = self.target_critic2([next_states, next_actions], training=False)
+        new_q  = tf.math.minimum(new_q1, new_q2)
+        # Bellman equation for the q value
+        # tf.print("SHAPES: ", states.shape, actions.shape, rewards.shape, new_q.shape, next_lp.shape)
+        # tf.print("Rewards: ", rewards)
+        q_targets = rewards + (1.0 - dones[:,None]) * self.gamma * (new_q - self.alpha * next_lp)
+        # Critic 1
+        with tf.GradientTape() as tape:
+            q_values1 = self.critic1([states, actions], training=True)
+            td_errors1 = q_values1 - q_targets
+            critic_loss1 = tf.reduce_mean(tf.math.square(td_errors1))
+        # tf.print("Critic 1 Loss: ", critic_loss1)
+        gradient1 = tape.gradient(critic_loss1, self.critic1.trainable_variables)
+        self.critic1.optimizer.apply_gradients(zip(gradient1, self.critic1.trainable_variables))
+
+        # Critic 2
+        with tf.GradientTape() as tape:
+            q_values2 = self.critic2([states, actions], training=True)
+            td_errors2 = q_values2 - q_targets
+            critic_loss2 = tf.reduce_mean(tf.math.square(td_errors2))
+        # tf.print("Critic 2 Loss: ", critic_loss2)
+        gradient2 = tape.gradient(critic_loss2, self.critic2.trainable_variables)
+        self.critic2.optimizer.apply_gradients(zip(gradient2, self.critic2.trainable_variables))
+
+    @tf.function
+    def train_actor(self, states):
+        # Use Critic 1
+        with tf.GradientTape() as tape:
+            sampled_means, sampled_sds = self.actor(states)
+            dist         = tfp.distributions.TruncatedNormal(sampled_means, sampled_sds, self.lower_bound, self.upper_bound)
+            # dist         = tfp.distributions.Normal(sampled_means, sampled_sds)
+            actions      = dist.sample()
+            # actions      = tf.clip_by_value(actions, self.lower_bound, self.upper_bound)
+            action_lp    = tf.reduce_sum(dist.log_prob(actions), axis=1)
+            q_value      = self.critic1([states, actions], training=True)
+            loss         = -tf.math.reduce_mean(q_value - self.alpha * action_lp)
+        # tf.print("Actor Loss: ", loss)
+        gradient = tape.gradient(loss, self.actor.trainable_variables)
+        self.actor.optimizer.apply_gradients(zip(gradient, self.actor.trainable_variables))
+
+    @tf.function
+    def soft_update(self, target_weights, weights):
+        for (target_weight, weight) in zip(target_weights, weights):
+            target_weight.assign(weight * self.tau + target_weight * (1.0 - self.tau))
+
+    def update(self, state_batch, action_batch, reward_batch, next_state_batch, done_batch):
+        if self.ntrain_calls % self.critic_update_freq == 0:
+            self.train_critic(state_batch, action_batch, reward_batch, next_state_batch, done_batch)
+        if self.ntrain_calls % self.actor_update_freq == 0:
+            self.train_actor(state_batch)
+
+    def _convert_to_tensor(self, state_batch, action_batch, reward_batch, next_state_batch, terminal_batch):
+        state_batch      = tf.convert_to_tensor(state_batch, dtype=tf.float32)
+        action_batch     = tf.convert_to_tensor(action_batch, dtype=tf.float32)
+        reward_batch     = tf.convert_to_tensor(reward_batch, dtype=tf.float32)
+        next_state_batch = tf.convert_to_tensor(next_state_batch, dtype=tf.float32)
+        terminal_batch   = tf.convert_to_tensor(terminal_batch, dtype=tf.float32)
+        return state_batch, action_batch, reward_batch, next_state_batch, terminal_batch
+
+    def generate_data(self):
+        state_batch, action_batch, reward_batch, next_state_batch, done_batch = \
+            self._convert_to_tensor(*self.memory.sample(self.batch_size))
+        yield state_batch, action_batch, reward_batch, next_state_batch, done_batch
+
+    def train(self, batch):
+        """ Method used to train """
+        self.ntrain_calls += 1
+        self.update(batch[0], batch[1], batch[2], batch[3], batch[4])
+        self.update_target()
+
+    def update_target(self):
+        if self.ntrain_calls % self.target_update_freq == 0:
+            self.soft_update(self.target_actor.variables, self.actor.variables)
+            self.soft_update(self.target_critic1.variables, self.critic1.variables)
+            self.soft_update(self.target_critic2.variables, self.critic2.variables)
+
+    def action(self, state, use_target=False):
+        """ Method used to provide the next action using the target model """
+        tf_state = tf.expand_dims(tf.convert_to_tensor(state), 0)
+        if use_target:
+            sampled_means, sampled_sds = tf.squeeze(self.target_actor(tf_state))
+        else:
+            sampled_means, sampled_sds = tf.squeeze(self.actor(tf_state))
+        dist = tfp.distributions.TruncatedNormal(sampled_means, sampled_sds, self.lower_bound, self.upper_bound)
+        # dist = tfp.distributions.Normal(sampled_means, sampled_sds)
+        sampled_actions = dist.sample()
+
+        # sampled_actions = sampled_means + sampled_sds * np.random.normal(0, 1.0, sampled_means.shape)
+        policy_type = 1
+
+        # We make sure action is within bounds
+        legal_action = np.clip(sampled_actions, self.lower_bound, self.upper_bound)
+        # log_p        = dist.log_prob(legal_action)
+
+        return legal_action, policy_type
+
+    def remember(self, state, action, reward, next_state, done):
+        self.memory.store(state, action, reward, next_state, done)
+
+    def has_data(self):
+        """return true if agent has experiences from simulation
+        """
+        return (self.memory._mem_length > 0)
+
+    # For distributed actors #
+    def get_weights(self):
+        return self.target_actor.get_weights()
+
+    def set_weights(self, weights):
+        self.target_actor.set_weights(weights)
+
+    def train_return(self, args):
+        pass
+
+
+class SAC_squash(SAC):
+    def __init__(self, env, is_learner, **kwargs):
+        """ Define all key variables required for all agent """
+
+        self.is_learner = is_learner
+        # Get env info
+        super().__init__(env, is_learner, **kwargs)
+
+        self.target_actor  = Tensorflow_Model.create("SoftActorUnbounded",
+                                              observation_space=env.observation_space,
+                                              action_space=env.action_space,
+                                              use_gpu=self.is_learner)
+        self.actor  = Tensorflow_Model.create("SoftActorUnbounded",
+                                              observation_space=env.observation_space,
+                                              action_space=env.action_space,
+                                              use_gpu=self.is_learner)
+
+        self.actor.init_model()
+        self.actor.print()
+        self.target_actor.init_model()
+
+        self.target_actor.set_weights(self.actor.get_weights())
+
+    @tf.function
+    def train_critic(self, states, actions, rewards, next_states, dones):
+
+        sampled_means, sampled_sds = self.actor(next_states)
+        dist         = tfp.distributions.Normal(sampled_means, sampled_sds)
+        raw_actions  = dist.sample()
+        next_actions = (tf.tanh(raw_actions) + 1.0) / 2.0 *(self.upper_bound - self.lower_bound) + self.lower_bound
+        next_lp      = tf.reduce_sum(dist.log_prob(raw_actions),axis=1) - tf.reduce_sum(tf.math.log(1 - tf.math.square(tf.math.tanh(raw_actions))), axis=1)
+
+        # Add a little noise
+        new_q1 = self.target_critic1([next_states, next_actions], training=False)
+        new_q2 = self.target_critic2([next_states, next_actions], training=False)
+        new_q  = tf.math.minimum(new_q1, new_q2)
+        # Bellman equation for the q value
+        # tf.print("SHAPES: ", states.shape, actions.shape, rewards.shape, new_q.shape, next_lp.shape)
+        # tf.print("Rewards: ", rewards)
+        q_targets = rewards + (1.0 - dones[:,None]) * self.gamma * (new_q - self.alpha * next_lp)
+        # Critic 1
+        with tf.GradientTape() as tape:
+            q_values1 = self.critic1([states, actions], training=True)
+            td_errors1 = q_values1 - q_targets
+            critic_loss1 = tf.reduce_mean(tf.math.square(td_errors1))
+        # tf.print("Critic 1 Loss: ", critic_loss1)
+        gradient1 = tape.gradient(critic_loss1, self.critic1.trainable_variables)
+        self.critic1.optimizer.apply_gradients(zip(gradient1, self.critic1.trainable_variables))
+
+        # Critic 2
+        with tf.GradientTape() as tape:
+            q_values2 = self.critic2([states, actions], training=True)
+            td_errors2 = q_values2 - q_targets
+            critic_loss2 = tf.reduce_mean(tf.math.square(td_errors2))
+        # tf.print("Critic 2 Loss: ", critic_loss2)
+        gradient2 = tape.gradient(critic_loss2, self.critic2.trainable_variables)
+        self.critic2.optimizer.apply_gradients(zip(gradient2, self.critic2.trainable_variables))
+
+    @tf.function
+    def train_actor(self, states):
+        # Use Critic 1
+        with tf.GradientTape() as tape:
+            sampled_means, sampled_sds = self.actor(states)
+            dist         = tfp.distributions.Normal(sampled_means, sampled_sds)
+            raw_actions  = dist.sample()
+            actions      = (tf.tanh(raw_actions) + 1.0) / 2.0 *(self.upper_bound - self.lower_bound) + self.lower_bound
+            action_lp    = tf.reduce_sum(dist.log_prob(raw_actions),axis=1) - tf.reduce_sum(tf.math.log(1 - tf.math.square(tf.math.tanh(raw_actions))), axis=1)
+            q_value      = self.critic1([states, actions], training=True)
+            loss         = -tf.math.reduce_mean(q_value - self.alpha * action_lp)
+        # tf.print("Actor Loss: ", loss)
+        gradient = tape.gradient(loss, self.actor.trainable_variables)
+        self.actor.optimizer.apply_gradients(zip(gradient, self.actor.trainable_variables))
+
+    def action(self, state, use_target=False):
+        """ Method used to provide the next action using the target model """
+        tf_state = tf.expand_dims(tf.convert_to_tensor(state), 0)
+        if use_target:
+            sampled_means, sampled_sds = tf.squeeze(self.target_actor(tf_state))
+        else:
+            sampled_means, sampled_sds = tf.squeeze(self.actor(tf_state))
+        # dist = tfp.distributions.TruncatedNormal(sampled_means, sampled_sds, self.lower_bound, self.upper_bound)
+        dist = tfp.distributions.Normal(sampled_means, sampled_sds)
+        sampled_actions = dist.sample()
+        sampled_actions = (tf.tanh(sampled_actions) + 1.0) / 2.0 *(self.upper_bound - self.lower_bound) + self.lower_bound
+
+        policy_type = 1
+        # tf.print("Means: ", sampled_means)
+        # tf.print("SDs: ", sampled_sds)
+        # tf.print("Actions: ", sampled_actions)
+
+        # We make sure action is within bounds
+        legal_action = np.clip(sampled_actions, self.lower_bound, self.upper_bound)
+        # log_p        = dist.log_prob(legal_action)
+
+        return legal_action, policy_type
+

--- a/exarl/agents/agent_vault/keras_td3.py
+++ b/exarl/agents/agent_vault/keras_td3.py
@@ -128,7 +128,7 @@ class KerasTD3(exarl.ExaAgent):
     def train_critic(self, states, actions, rewards, next_states, dones):
         next_actions = self.target_actor(next_states, training=False)
         # Add a little noise
-        noise = np.random.normal(0, 0.2, self.num_actions)
+        noise = np.random.normal(0, 0.2, next_actions.shape)
         noise = np.clip(noise, -0.5, 0.5)
         next_actions = next_actions * (1 + noise)
         new_q1 = self.target_critic1([next_states, next_actions], training=False)
@@ -254,7 +254,7 @@ class KerasTD3(exarl.ExaAgent):
         """ Method used to provide the next action using the target model """
         tf_state = tf.expand_dims(tf.convert_to_tensor(state), 0)
         sampled_actions = tf.squeeze(self.actor(tf_state))
-        noise = np.random.normal(0, 0.1, self.num_actions)
+        noise = np.random.normal(0, 0.1, sampled_actions.shape)
         sampled_actions = sampled_actions.numpy() * (1 + noise)
         policy_type = 1
 

--- a/exarl/agents/models/__init__.py
+++ b/exarl/agents/models/__init__.py
@@ -1,10 +1,16 @@
 from exarl.agents.models.tf_model import Tensorflow_Model
 from exarl.agents.models.tf_mlp import MLP
 from exarl.agents.models.tf_lstm import LSTM
+from exarl.agents.models.tf_sac import SoftActorUnbounded
+from exarl.agents.models.tf_sac import SoftActor
 from exarl.agents.models.tf_ac import Actor
+from exarl.agents.models.tf_sac import SoftCritic
 from exarl.agents.models.tf_ac import Critic
 
 Tensorflow_Model.register("MLP", MLP)
 Tensorflow_Model.register("LSTM", LSTM)
-Tensorflow_Model.register("Actor", Actor)
+Tensorflow_Model.register("SoftActor", SoftActor)
+Tensorflow_Model.register("SoftCritic", SoftCritic)
+Tensorflow_Model.register("SoftActorUnbounded", SoftActorUnbounded)
 Tensorflow_Model.register("Critic", Critic)
+Tensorflow_Model.register("Actor", Actor)

--- a/exarl/agents/models/tf_ac.py
+++ b/exarl/agents/models/tf_ac.py
@@ -52,7 +52,7 @@ class Actor(Tensorflow_Model):
         for i in range(len(self.actor_dense)):
             layers.append(Dense(self.actor_dense[i], activation=self.actor_dense_act)(layers[-1]))
         layers.append(Dense(self.n_actions, activation=self.actor_out_act, kernel_initializer=last_init)(layers[-1]))
-        layers.append(Lambda(lambda i: i * self.upper_bound)(layers[-1]))
+        layers.append(Lambda(lambda i: i * (self.upper_bound - self.lower_bound) + self.lower_bound)(layers[-1]))
         self._model = Model(inputs=layers[0], outputs=layers[-1])
      
 class Critic(Tensorflow_Model):

--- a/exarl/agents/models/tf_ac.py
+++ b/exarl/agents/models/tf_ac.py
@@ -41,6 +41,7 @@ class Actor(Tensorflow_Model):
         
         self.upper_bound = action_space.high
         self.lower_bound = action_space.low
+        self.n_actions   = action_space.shape[0]
 
     def _build(self):
         last_init = tf.random_uniform_initializer()
@@ -50,7 +51,7 @@ class Actor(Tensorflow_Model):
         layers.append(Input(shape=(flatdim(self.observation_space),), batch_size=self.batch_size))
         for i in range(len(self.actor_dense)):
             layers.append(Dense(self.actor_dense[i], activation=self.actor_dense_act)(layers[-1]))
-        layers.append(Dense(1, activation=self.actor_out_act, kernel_initializer=last_init)(layers[-1]))
+        layers.append(Dense(self.n_actions, activation=self.actor_out_act, kernel_initializer=last_init)(layers[-1]))
         layers.append(Lambda(lambda i: i * self.upper_bound)(layers[-1]))
         self._model = Model(inputs=layers[0], outputs=layers[-1])
      

--- a/exarl/agents/models/tf_sac.py
+++ b/exarl/agents/models/tf_sac.py
@@ -1,0 +1,154 @@
+# This material was prepared as an account of work sponsored by an agency of the
+# United States Government.  Neither the United States Government nor the United
+# States Department of Energy, nor Battelle, nor any of their employees, nor any
+# jurisdiction or organization that has cooperated in the development of these
+# materials, makes any warranty, express or implied, or assumes any legal
+# liability or responsibility for the accuracy, completeness, or usefulness or
+# any information, apparatus, product, software, or process disclosed, or
+# represents that its use would not infringe privately owned rights. Reference
+# herein to any specific commercial product, process, or service by trade name,
+# trademark, manufacturer, or otherwise does not necessarily constitute or imply
+# its endorsement, recommendation, or favoring by the United States Government
+# or any agency thereof, or Battelle Memorial Institute. The views and opinions
+# of authors expressed herein do not necessarily state or reflect those of the
+# United States Government or any agency thereof.
+#                 PACIFIC NORTHWEST NATIONAL LABORATORY
+#                            operated by
+#                             BATTELLE
+#                             for the
+#                   UNITED STATES DEPARTMENT OF ENERGY
+#                    under Contract DE-AC05-76RL01830
+import tensorflow as tf
+from tensorflow.keras.models import Model
+from tensorflow.keras.layers import Dense, Input, Concatenate, Lambda
+from gym.spaces.utils import flatdim
+from exarl.agents.models.tf_model import Tensorflow_Model
+from exarl.utils.globals import ExaGlobals
+
+class SoftActor(Tensorflow_Model):
+    def __init__(self, observation_space, action_space, use_gpu=True):
+        super(SoftActor, self).__init__(observation_space, action_space, use_gpu)
+        self.batch_size = ExaGlobals.lookup_params('batch_size')
+        self.actor_dense = ExaGlobals.lookup_params('actor_dense')
+        self.actor_dense_act = ExaGlobals.lookup_params('actor_dense_act')
+        self.actor_out_act = ExaGlobals.lookup_params('actor_out_act')
+
+        assert len(self.actor_dense) >= 1, "Must have at least one actor_dense layer: {}".format(len(self.actor_dense))
+
+        self.loss = None
+        self.actor_lr = ExaGlobals.lookup_params('actor_lr')
+        self.optimizer = tf.keras.optimizers.Adam(self.actor_lr)
+        
+        self.upper_bound = action_space.high
+        self.lower_bound = action_space.low
+        self.n_actions   = action_space.shape[0]
+
+    def _build(self):
+        last_init = tf.random_uniform_initializer()
+        last_init = tf.random_uniform_initializer(minval=-0.003, maxval=0.003)
+
+        layers = []
+        layers.append(Input(shape=(flatdim(self.observation_space),), batch_size=self.batch_size))
+        for i in range(len(self.actor_dense)):
+            layers.append(Dense(self.actor_dense[i], activation=self.actor_dense_act)(layers[-1]))
+        layers.append(Dense(self.n_actions, activation=self.actor_out_act, kernel_initializer=last_init)(layers[-1]))
+        layers.append(Lambda(lambda i: i * (self.upper_bound - self.lower_bound) + self.lower_bound)(layers[-1]))
+
+        layers.append(Dense(self.n_actions, activation=self.actor_out_act, kernel_initializer=last_init)(layers[-3]))
+        # layers.append(Lambda(lambda x: tf.exp(x) )(layers[-1]))
+        layers.append(Lambda(lambda x: tf.exp(x * (5.0 - (-5.0)) - 5.0))(layers[-1]))
+        self._model = Model(inputs=layers[0], outputs=[layers[-3], layers[-1]])
+
+    def _compile(self):
+        """
+        This internal function compiles a tf model.
+        """
+        with tf.device(self._device):
+            self._build()
+            self._model.compile(loss=self.loss, optimizer=self.optimizer, jit_compile=self.enable_xla)
+
+class SoftCritic(Tensorflow_Model):
+    def __init__(self, observation_space, action_space, use_gpu=True):
+        super(SoftCritic, self).__init__(observation_space, action_space, use_gpu)
+        self.batch_size = ExaGlobals.lookup_params('batch_size')
+
+        self.critic_state_dense = ExaGlobals.lookup_params('critic_state_dense')
+        self.critic_state_dense_act = ExaGlobals.lookup_params('critic_state_dense_act')
+        self.critic_action_dense = ExaGlobals.lookup_params('critic_action_dense')
+        self.critic_action_dense_act = ExaGlobals.lookup_params('critic_action_dense_act')
+
+        self.critic_concat_dense = ExaGlobals.lookup_params('critic_concat_dense')
+        self.critic_concat_dense_act = ExaGlobals.lookup_params('critic_concat_dense_act')
+
+        assert len(self.critic_state_dense) >= 1, "Must have at least one critic_state_dense layer: {}".format(len(self.critic_state_dense))
+        assert len(self.critic_action_dense) >= 1, "Must have at least one critic_action_dense layer: {}".format(len(self.critic_action_dense))
+        assert len(self.critic_concat_dense) >= 1, "Must have at least one critic_concat_dense layer: {}".format(len(self.critic_concat_dense))
+
+        self.loss = None
+        self.critic_lr = ExaGlobals.lookup_params('critic_lr')
+        self.optimizer = tf.keras.optimizers.Adam(self.critic_lr)
+
+    def _build(self):
+        state_layers = []
+        state_layers.append(Input(shape=(flatdim(self.observation_space),), batch_size=self.batch_size))
+        for i in range(len(self.critic_state_dense)):
+            state_layers.append(Dense(self.critic_state_dense[i], activation=self.critic_state_dense_act)(state_layers[-1]))
+
+        action_layers = []
+        action_layers.append(Input(shape=(flatdim(self.action_space),), batch_size=self.batch_size))
+        for i in range(len(self.critic_action_dense)):
+            action_layers.append(Dense(self.critic_action_dense[i], activation=self.critic_action_dense_act)(action_layers[-1]))
+
+        # action_sd_layers = []
+        # action_sd_layers.append(Input(shape=(flatdim(self.action_space),), batch_size=self.batch_size))
+        # for i in range(len(self.critic_action_dense)):
+        #     action_sd_layers.append(Dense(self.critic_action_dense[i], activation=self.critic_action_dense_act)(action_sd_layers[-1]))
+
+        concat_layers = []
+        concat_layers.append(Concatenate()([state_layers[-1], action_layers[-1]]))
+        for i in range(len(self.critic_concat_dense)):
+            concat_layers.append(Dense(self.critic_concat_dense[i], activation=self.critic_concat_dense_act)(concat_layers[-1]))
+        
+        concat_layers.append(Dense(1)(concat_layers[-1]))
+        self._model = Model([state_layers[0], action_layers[0]], concat_layers[-1])
+
+class SoftActorUnbounded(Tensorflow_Model):
+    def __init__(self, observation_space, action_space, use_gpu=True):
+        super(SoftActorUnbounded, self).__init__(observation_space, action_space, use_gpu)
+        self.batch_size = ExaGlobals.lookup_params('batch_size')
+        self.actor_dense = ExaGlobals.lookup_params('actor_dense')
+        self.actor_dense_act = ExaGlobals.lookup_params('actor_dense_act')
+        self.actor_out_act = ExaGlobals.lookup_params('actor_out_act')
+
+        assert len(self.actor_dense) >= 1, "Must have at least one actor_dense layer: {}".format(len(self.actor_dense))
+
+        self.loss = None
+        self.actor_lr = ExaGlobals.lookup_params('actor_lr')
+        self.optimizer = tf.keras.optimizers.Adam(self.actor_lr)
+        
+        self.upper_bound = action_space.high
+        self.lower_bound = action_space.low
+        self.n_actions   = action_space.shape[0]
+
+    def _build(self):
+        last_init = tf.random_uniform_initializer()
+        last_init = tf.random_uniform_initializer(minval=-0.003, maxval=0.003)
+
+        layers = []
+        layers.append(Input(shape=(flatdim(self.observation_space),), batch_size=self.batch_size))
+        for i in range(len(self.actor_dense)):
+            layers.append(Dense(self.actor_dense[i], activation=self.actor_dense_act)(layers[-1]))
+        layers.append(Dense(self.n_actions, kernel_initializer=last_init)(layers[-1]))
+
+        layers.append(Dense(self.n_actions, kernel_initializer=last_init)(layers[-2]))
+        layers.append(Lambda(lambda x: tf.exp(x) )(layers[-1]))
+        self._model = Model(inputs=layers[0], outputs=[layers[-3], layers[-1]])
+
+    def _compile(self):
+        """
+        This internal function compiles a tf model.
+        """
+        with tf.device(self._device):
+            self._build()
+            self._model.compile(loss=self.loss, optimizer=self.optimizer, jit_compile=self.enable_xla)
+

--- a/exarl/candlelib/default_utils.py
+++ b/exarl/candlelib/default_utils.py
@@ -477,6 +477,8 @@ def get_common_parser(parser):
 
     parser.add_argument("--horizon", default=1, type=int, help="nStep buffer hoizon for DDPG and TD3 Calculations")
 
+    parser.add_argument("--sac_alpha", default=0.01, type=float, help="Alpha parameter for Soft Actor-Critic, which balances the entropy and reward terms in the Q-loss.")
+
     # Model definition
     # Model Architecture
     parser.add_argument(

--- a/exarl/config/agent_cfg/SAC-v0.json
+++ b/exarl/config/agent_cfg/SAC-v0.json
@@ -1,0 +1,7 @@
+{
+    "buffer_capacity": 50000,
+    "batch_size": 64,
+    "sac_alpha": 0.01,
+    "tau": 0.01,
+    "gamma": 0.99
+}

--- a/exarl/config/agent_cfg/SAC-v1.json
+++ b/exarl/config/agent_cfg/SAC-v1.json
@@ -1,0 +1,7 @@
+{
+    "buffer_capacity": 50000,
+    "batch_size": 64,
+    "sac_alpha": 0.01,
+    "tau": 0.01,
+    "gamma": 0.99
+}

--- a/exarl/config/model_cfg/AC.json
+++ b/exarl/config/model_cfg/AC.json
@@ -2,7 +2,7 @@
     "actor_lr" : 0.001,
     "actor_dense_act" : "relu",
     "actor_dense": [256, 256],
-    "actor_out_act" : "tanh",
+    "actor_out_act" : "sigmoid",
     "actor_optimizer" : "adam",
 
     "critic_lr" : 0.002,


### PR DESCRIPTION
Added the Soft Actor-Critic method from Haarnoja (2018) to ExaRL as an alternative to TD3 and DDPG. I have tested this on Pendulum and it worked very well. The version of this compatible with newer gym/tensorflow has also been tested on the Humanoid and Hopper from MuJoCo and showed behavior consistent with Haarnoja (2018), which indicates it works to some extent. 

I would really love to see someone throw this at the 39-bus powergrid example and see if it works at all. Probably with the following flags:
--horizon 1 --actor_lr 0.0002 --critic_lr 0.0004 --sac_alpha 0.05